### PR TITLE
Introduce forked types and GraphQL fields for `juniper-react`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ index*.js.map
 # Decrypted secrets
 secrets.json
 .nvmrc
+.npmrc
 
 # IDE settings
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,14 @@ types.js
 optimized-types.js
 
 # Build artifacts
-index.*
+index*.js
+index*.js.map
 !docs/index.html
 
 # Decrypted secrets
 secrets.json
 .nvmrc
 
-# VSCode settings
+# IDE settings
 .vscode
+.idea

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,503 @@
+// Type definitions for shopify-buy 2.10
+// Project: https://github.com/Shopify/js-buy-sdk#readme
+// Definitions by: Martin Köhn <https://github.com/openminder>
+//                 Stephen Traiforos <https://github.com/straiforos>
+//                 Juan Manuel Incaurgarat <https://github.com/kilinkis>
+//                 Chris Worman <https://github.com/chrisworman-pela>
+//                 Maciej Baron <https://github.com/MaciekBaron>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+/**
+ * The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website.
+ * It is based on Shopify’s API and provides the ability to retrieve products and collections from your shop,
+ * add products to a cart, and checkout.
+ * It can render data on the client side or server. This will allow you to add ecommerce functionality to any
+ * website or javascript application. This is helpful if you already have a website and need to add ecommerce
+ * or only need a simple buy button on your site.
+ */
+
+declare namespace ShopifyBuy {
+    export function buildClient(config: Config): Client;
+
+    export interface Client {
+        product: ShopifyBuy.ProductResource;
+        collection: ShopifyBuy.CollectionResource;
+        checkout: ShopifyBuy.CheckoutResource;
+        shop: ShopResource;
+        image: Image;
+        fetchNextPage<T extends GraphModel>(nextArray: T[]): T[];
+    }
+
+    export interface Config {
+        domain: string;
+        storefrontAccessToken: string;
+        language?: string | undefined;
+    }
+
+    export interface ProductResource {
+        fetch(id: string): Promise<Product>;
+        fetchAll(pageSizeopt?: number): Promise<Product[]>;
+        fetchByHandle(handle: string): Promise<Product>;
+        fetchMultiple(ids: string[]): Promise<Product[]>;
+        fetchQuery(query: Query): Promise<Product[]>;
+
+        /**
+         *   Product Helper Namespace
+         *   @link https://shopify.github.io/js-buy-sdk/ProductResource.html
+         */
+        variantForOptions(product: Product, options: Option): ProductVariant;
+    }
+
+    export interface CollectionResource {
+        fetch(id: string): Promise<Product[]>;
+        fetchWithProducts(id: string): Promise<any[]>; // TODO fix to be a type: Docs: Fetches a single collection by ID on the shop, not including products.
+        fetchAll(pageSizeopt?: number): Promise<any[]>; // TODO fix to be a type: Docs: Fetches all collections on the shop, not including products.
+        fetchAllWithProducts(): Promise<any[]>; // TODO fix to be a type: DOC: Fetches all collections on the shop, including products.
+        fetchByHandle(handle: string): Promise<any[]>; // TODO fix to be a type: DOC: Fetches a collection by handle on the shop. Assuming it does not give products
+        fetchQuery(query: Query): Promise<any[]>; // TODO fix to be a type: DOC: Fetches a collection by handle on the shop. Assuming it does not give products
+    }
+
+    export interface CheckoutResource {
+        create(
+            email?: string,
+            lineItems?: LineItem[],
+            shippingAddress?: Address,
+            note?: string,
+            customAttributes?: AttributeInput[],
+        ): Promise<Cart>;
+
+        fetch(id: string): Promise<Cart>;
+
+        addLineItems(checkoutId: string | number, lineItems: LineItemToAdd[]): Promise<Cart>;
+
+        /**
+         * Remove all line items from cart
+         */
+        clearLineItems(checkoutId: string | number, lineItems: LineItem[]): Promise<Cart>;
+
+        /**
+         * Add items to cart. Updates cart's lineItems
+         */
+        addVariants(item: Item, nextItem?: Array<Item>): Promise<Cart>;
+
+        /**
+         * Remove a line item from cart based on line item id
+         */
+        removeLineItems(checkoutId: string | number, lineItemIds: string[]): Promise<Cart>;
+
+        /**
+         * Add discount to cart
+         */
+        addDiscount(checkoutId: string | number, discountCode: string): Promise<Cart>;
+
+        /**
+         * Remove discounts from cart
+         */
+        removeDiscount(checkoutId: string | number): Promise<Cart>;
+
+        /**
+         * Update line item quantities based on an array of line item ids
+         */
+        updateLineItems(checkoutId: string | number, lineItems: AttributeInput[]): Promise<Cart>;
+    }
+
+    export interface ShopResource {
+        fetchInfo(): Promise<Shop>;
+        fetchPolicies(): Promise<Shop>;
+    }
+
+    export interface Query {
+        /**
+         * query: title, collection_type, updated_at
+         * TODO probably will remove before Defintely Typed PR,
+         * as their  community guidelines
+         */
+        query: string;
+        sortKey: string;
+        after?: string | undefined;
+        before?: string | undefined;
+        first?: number | undefined;
+        last?: number | undefined;
+        reverse?: boolean | undefined;
+    }
+
+    export interface Product extends GraphModel {
+        /**
+         * A product description.
+         */
+        description: string;
+
+        /**
+         * Product unique ID
+         */
+        id: string | number;
+
+        /**
+         * An Array of Objects that contain meta data about an image including src of the images.
+         */
+        images: Array<Image>;
+
+        /**
+         * All variants of a product.
+         */
+        variants: Array<ProductVariant>;
+
+        /**
+         * Get an array of Product Options. Product Options can be used to define
+         * the currently selectedVariant from which you can get a checkout url (ProductVariant.checkoutUrl)
+         * or can be added to a cart (Cart.createLineItemsFromVariants).
+         */
+        options: Array<Option>;
+
+        /**
+         * Retrieve variant for currently selected options. By default the first value in each option is selected
+         * which means selectedVariant will never be null. With a selectedVariant you can
+         * create checkout url (ProductVariant.checkoutUrl) or
+         * it can be added to a cart (Cart.createLineItemsFromVariants).
+         */
+        selectedVariant: ProductVariant;
+
+        /**
+         * Retrieve image for currently selected variantImage.
+         */
+        selectedVariantImage: Image;
+
+        /**
+         * A read only Array of Strings represented currently selected option values. eg. ["Large", "Red"]
+         */
+        selections: Array<string>;
+
+        /**
+         * The product title
+         */
+        title: string;
+
+        /**
+         * The product’s vendor name
+         */
+        vendor: string;
+    }
+
+    export interface ProductVariant extends GraphModel {
+        /**
+         * Variant in stock. Always true if inventory tracking is disabled.
+         */
+        available: boolean;
+
+        /**
+         * Compare at price for variant. The compareAtPrice would be the price of the
+         * product previously before the product went on sale.
+         */
+        compareAtPrice: string;
+
+        /**
+         * Price of variant, formatted according to shop currency format string. For instance "$10.00"
+         */
+        formattedPrice: string;
+
+        /**
+         * Variant weight in grams. If no weight is defined grams will be 0.
+         */
+        grams: number;
+
+        /**
+         * Variant unique ID
+         */
+        id: string | number;
+
+        /**
+         * Image for variant
+         */
+
+        image: Image;
+
+        /**
+         * Image variants available for a variant.
+         */
+        imageVariant: Array<ImageVariant>;
+
+        /**
+         * Option values associated with this variant, ex {name: "color", value: "Blue"}
+         */
+        optionValues: Array<OptionValue>;
+
+        /**
+         * Price of the variant. The price will be in the following form: "10.00"
+         */
+        price: string;
+
+        /**
+         * ID of product variant belongs to
+         */
+        productId: string | number;
+
+        /**
+         * Title of product variant belongs to
+         */
+        productTitle: string;
+
+        /**
+         * Title of variant
+         */
+        title: string;
+
+        /*
+         * Get a checkout url for a specific product variant.
+         * You can optionally pass a quantity.
+         * If no quantity is passed then quantity will default to 1.
+         */
+        checkoutUrl(quantitiy: number): string;
+    }
+
+    export interface Option {
+        /**
+         * name of option (ex. "Size", "Color")
+         */
+        name: string;
+
+        /**
+         * get/set the currently selected option value with one of the values from the Product Options/values array.
+         * For instance if the option values array had the following ["Large", "Medium", "Small"] setting selected to be
+         * "Large", "Medium", or "Small" would be valid any other value would throw an Error.
+         */
+        selected: string;
+
+        /**
+         * an Array possible values for option. For instance if this option
+         * is a "Size" option an example value for values could be: ["Large", "Medium", "Small"]
+         */
+        values: Array<OptionValue>;
+    }
+
+    export interface OptionValue {
+        name: string;
+        option_id: string;
+        value: any;
+    }
+
+    export interface CustomAttribute {
+        key: string;
+        value: string;
+    }
+
+    export interface CustomAttributeV2 {
+        customAttributes: {
+            key: string;
+            value: string;
+        }[];
+    }
+
+    export interface Collection {
+        handle: string;
+        body_html: string;
+        image: Image;
+        id: string;
+        metafields: any[];
+        published: boolean;
+        published_at: string;
+        published_scope: string;
+        sort_order: string;
+        template_suffix: string;
+        title: string;
+        updated_at: string;
+    }
+
+    export interface Cart extends GraphModel {
+        /**
+         * Get checkout URL for current cart
+         */
+        checkoutUrl: string;
+
+        /**
+         * get ID for current cart
+         */
+        id: string | number;
+
+        /**
+         * Gets the total quantity of all line items. Example: you've added two variants
+         * with quantities 3 and 2. lineItemCount will be 5.
+         */
+        lineItemCount: number;
+
+        /**
+         * Get an Array of CartLineItemModel's
+         */
+        lineItems: LineItem[];
+
+        /**
+         * Get current subtotal price for all line items, before shipping, taxes, and discounts.
+         * Example: two items have been added to the cart that cost $1.25 then the subtotal will be 2.50
+         */
+        subtotalPrice: string;
+
+        /**
+         * Get completed at date.
+         */
+        completedAt: string | null;
+
+        /**
+         * Get checkout url
+         */
+        webUrl: string;
+    }
+
+    export interface LineItem extends GraphModel {
+        /**
+         * Compare at price for variant. The compareAtPrice would be the price of the product
+         * previously before the product went on sale.
+         * If no compareAtPrice is set then this value will be null. An example value: "5.00".
+         */
+        compareAtPrice: string | null;
+
+        /**
+         * Variant's weight in grams. If no weight is set then 0 is returned.
+         */
+        grams: number;
+
+        /**
+         * A line item ID.
+         */
+        id: string | number;
+
+        /**
+         * Variant's image.
+         */
+        image: Image;
+
+        /**
+         * The total price for this line item. For instance if the variant costs 1.50 and you have a
+         * quantity of 2 then line_price will be 3.00.
+         */
+        linePrice: string;
+
+        /**
+         * Price of the variant. For example: "5.00".
+         */
+        price: string;
+
+        /**
+         * ID of variant's product.
+         */
+        productId: string | number;
+
+        /**
+         * Count of variants to order.
+         */
+        quantity: number;
+
+        /**
+         * Product title of variant's parent product.
+         */
+        title: string;
+
+        /**
+         * ID of line item variant.
+         */
+        variantId: string | number;
+
+        /**
+         * Title of variant.
+         */
+        variantTitle: string;
+    }
+
+    export interface LineItemToAdd {
+        variantId: string | number;
+        quantity: number;
+        customAttributes?: CustomAttribute[] | undefined;
+    }
+
+    export interface Item {
+        variant: ProductVariant;
+        quantity: number;
+    }
+
+    export interface Address {
+        address1: String;
+        address2: String;
+        city: String;
+        company: String;
+        country: String;
+        firstName: String;
+        lastName: String;
+        phone: String;
+        province: String;
+        zip: String;
+    }
+
+    /**
+     *  https://help.shopify.com/api/custom-storefronts/storefront-api/reference/input_object/attributeinput
+     *  https://help.shopify.com/api/custom-storefronts/storefront-api/reference/input_object/checkoutlineitemupdateinput
+     */
+    export interface AttributeInput {
+        key?: string | undefined;
+        value?: string | undefined;
+        id?: string | number | undefined;
+        quantity?: number | undefined;
+        variantId?: string | undefined;
+    }
+
+    /**
+     * TODO Validate schema matches js-buy
+     * Derived from REST API Docs: https://help.shopify.com/api/custom-storefronts/storefront-api/reference/object/shop#fields
+     */
+    export interface Shop {
+        description: string;
+        moneyFormat: string;
+        name: string;
+        /**
+         * TODO Add types for the Shop properties below
+         * PaymentSettings, ShopPolicy etc
+         */
+        paymentSettings: any;
+        primaryDomain: any;
+        privacyPolicy: any;
+        refundPolicy: any;
+        termsOfService: any;
+    }
+
+    /**
+     * Internal Image description
+     */
+    export interface Image extends GraphModel {
+        id: string | number;
+        created_at: string;
+        position: number;
+        updated_at: string;
+        product_id: string;
+        src: string;
+        variant_ids: Array<string>;
+    }
+
+    export interface ImageVariant extends Image {
+        name: string;
+        dimensions: string;
+        src: string;
+        /**
+         * Returns src URL for new image size/variant
+         * @param image The image you would like a different size for.
+         * @param options Image Max width and height configuration.
+         */
+        imageForSize(image: Image, options: ImageOptions): string;
+    }
+
+    export interface ImageOptions {
+        maxWidth: number;
+        maxHeight: number;
+    }
+
+    let NO_IMAGE_URI: string;
+
+    /*
+     *   Base Model for the higher level returned objects from the API using GraphQL
+     */
+    export interface GraphModel {
+        attrs?: any;
+        onlineStoreUrl?: string | undefined;
+    }
+}
+
+declare module 'shopify-buy' {
+    export = ShopifyBuy;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare namespace ShopifyBuy {
 
     export interface CollectionResource {
         fetch(id: string): Promise<Product[]>;
-        fetchWithProducts(id: string): Promise<any[]>; // TODO fix to be a type: Docs: Fetches a single collection by ID on the shop, not including products.
+        fetchWithProducts(id: string, options?: {productsFirst: number}): Promise<any[]>;
         fetchAll(pageSizeopt?: number): Promise<any[]>; // TODO fix to be a type: Docs: Fetches all collections on the shop, not including products.
         fetchAllWithProducts(): Promise<any[]>; // TODO fix to be a type: DOC: Fetches all collections on the shop, including products.
         fetchByHandle(handle: string): Promise<any[]>; // TODO fix to be a type: DOC: Fetches a collection by handle on the shop. Assuming it does not give products
@@ -177,6 +177,11 @@ declare namespace ShopifyBuy {
          * The product’s vendor name
          */
         vendor: string;
+
+        /**
+         * The product's tags.
+         */
+        tags: Scalar[];
     }
 
     export interface ProductVariant extends GraphModel {
@@ -195,6 +200,12 @@ declare namespace ShopifyBuy {
          * Price of variant, formatted according to shop currency format string. For instance "$10.00"
          */
         formattedPrice: string;
+
+        /**
+         *  Indicates whether the variant is out of stock but still available for purchase (used
+         *  for backorders).
+         */
+        currentlyNotInStock: boolean;
 
         /**
          * Variant weight in grams. If no weight is defined grams will be 0.
@@ -218,24 +229,19 @@ declare namespace ShopifyBuy {
         imageVariant: Array<ImageVariant>;
 
         /**
-         * Option values associated with this variant, ex {name: "color", value: "Blue"}
-         */
-        optionValues: Array<OptionValue>;
-
-        /**
          * Price of the variant. The price will be in the following form: "10.00"
          */
         price: string;
 
         /**
-         * ID of product variant belongs to
+         * A limited reference to the variant's product.
          */
-        productId: string | number;
+        product: ProductWithinVariant;
 
         /**
-         * Title of product variant belongs to
+         * Selected options.
          */
-        productTitle: string;
+        selectedOptions: SelectedOption[];
 
         /**
          * Title of variant
@@ -304,21 +310,11 @@ declare namespace ShopifyBuy {
     }
 
     export interface Cart extends GraphModel {
-        /**
-         * Get checkout URL for current cart
-         */
-        checkoutUrl: string;
 
         /**
          * get ID for current cart
          */
         id: string | number;
-
-        /**
-         * Gets the total quantity of all line items. Example: you've added two variants
-         * with quantities 3 and 2. lineItemCount will be 5.
-         */
-        lineItemCount: number;
 
         /**
          * Get an Array of CartLineItemModel's
@@ -392,14 +388,9 @@ declare namespace ShopifyBuy {
         title: string;
 
         /**
-         * ID of line item variant.
+         * Variant of the line item that also includes a reference back to its parent product.
          */
-        variantId: string | number;
-
-        /**
-         * Title of variant.
-         */
-        variantTitle: string;
+        variant: ProductVariant & {product: ProductWithinVariant};
     }
 
     export interface LineItemToAdd {
@@ -482,6 +473,11 @@ declare namespace ShopifyBuy {
         imageForSize(image: Image, options: ImageOptions): string;
     }
 
+    export interface SelectedOption {
+        name: string;
+        value: string;
+    }
+
     export interface ImageOptions {
         maxWidth: number;
         maxHeight: number;
@@ -496,8 +492,18 @@ declare namespace ShopifyBuy {
         attrs?: any;
         onlineStoreUrl?: string | undefined;
     }
+
+    /**
+     * A subset of a product object that only includes the id and title. This exists in
+     * variants, so that they each have a reference back to their parent product node.
+     */
+    export interface ProductWithinVariant extends Pick<Product, "title" | "id">{}
+
+    export interface Scalar {
+        value: string;
+    }
 }
 
-declare module 'shopify-buy' {
+declare module '@hellojuniper-com/shopify-buy' {
     export = ShopifyBuy;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.16.1",
+  "version": "0.0.1",
   "description": "The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website. It is based on Shopify's API and provides the ability to retrieve products and collections from your shop, add products to a cart, and checkout.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "0.0.1",
-  "description": "The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website. It is based on Shopify's API and provides the ability to retrieve products and collections from your shop, add products to a cart, and checkout.",
+  "version": "2.16.1",
+  "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",
   "repository": "git@github.com:hellojuniper-com/shopify-buy-sdk.git",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "jsnext:main": "index.es.js",
   "repository": "git@github.com:hellojuniper-com/shopify-buy-sdk.git",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "prepublish": "yarn run build",
     "build": "yarn run build:optimized && yarn run build:unoptimized",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,10 @@
 {
-  "name": "shopify-buy",
+  "name": "@hellojuniper-com/shopify-buy",
   "version": "2.16.1",
   "description": "The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website. It is based on Shopify's API and provides the ability to retrieve products and collections from your shop, add products to a cart, and checkout.",
   "main": "index.js",
   "jsnext:main": "index.es.js",
-  "repository": "git@github.com:Shopify/js-buy-sdk.git",
-  "publishConfig": {
-    "access": "public",
-    "@shopify:registry": "https://registry.npmjs.org/"
-  },
+  "repository": "git@github.com:hellojuniper-com/shopify-buy-sdk.git",
   "scripts": {
     "prepublish": "yarn run build",
     "build": "yarn run build:optimized && yarn run build:unoptimized",
@@ -32,7 +28,7 @@
     "minify-umd:optimized": "babel-minify index.umd.js > index.umd.min.js",
     "minify-umd:unoptimized": "babel-minify index.unoptimized.umd.js > index.unoptimized.umd.min.js"
   },
-  "author": "Shopify Inc.",
+  "author": "Juniper Creates",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -11,6 +11,7 @@ fragment ProductFragment on Product {
   vendor
   publishedAt
   onlineStoreUrl
+  tags
   options {
     name
     values

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -40,7 +40,7 @@ fragment ProductFragment on Product {
     edges {
       cursor
       node {
-        ...VariantFragment
+        ...VariantWithProductFragment
       }
     }
   }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -8,6 +8,7 @@ fragment VariantFragment on ProductVariant {
   }
   weight
   available: availableForSale
+  currentlyNotInStock
   sku
   compareAtPrice
   compareAtPriceV2 {

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -3,5 +3,6 @@ fragment VariantWithProductFragment on ProductVariant {
   product {
     id
     handle
+    title
   }
 }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1202954889576661/f

### Summary
* Added a copy of the type definitions in `@types/shopify-buy` and fixed all of the broken schemas. 
  * Note that this package is a part of the large [DefinitelyTyped mono-repo](https://github.com/DefinitelyTyped/DefinitelyTyped), so we decided to consolidate JS business logic and TS types into a single repository instead of forking the DefinitelyTyped mono-repo and messing with the build system.
* Updated `.gitignore` to accommodate our use cases.
* Exposed the missing GraphQL fields in the underlying queries:
  * [`Product->tags`](https://shopify.dev/api/storefront/2021-10/objects/Product#field-product-tags)
  * [`ProductVariant->currentlyNotInStock`](https://shopify.dev/api/storefront/2021-10/objects/ProductVariant#field-productvariant-currentlynotinstock)
  * [`ProductVariant->Product->title`](https://shopify.dev/api/storefront/2021-10/objects/Product#field-product-title)

### Performed Testing
Ran `yarn build` successfully and integrated it using NPM symlinks locally with `juniper-react`.
