### PR TITLE
[S/S Warehouse Pricing] Expose `metafields` and `quantity` fields on the Shopify `Product` and `Variant` models

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -206,6 +206,16 @@ declare namespace ShopifyBuy {
          * The product's tags.
          */
         tags: Scalar[];
+
+        /**
+         * The product's custom metafields.
+         */
+        metafields: Array<Metafield | null>
+
+        /**
+         * The sellable quantity of the product.
+         */
+        quantity: number;
     }
 
     export interface ProductVariant extends GraphModel {
@@ -256,6 +266,16 @@ declare namespace ShopifyBuy {
          * Title of variant
          */
         title: string;
+
+        /**
+         * The variant's custom metafields.
+         */
+        metafields: Array<Metafield | null>;
+
+        /**
+         * The sellable quantity of the variant.
+         */
+        quantity: number;
     }
 
     export interface ProductOption {
@@ -461,6 +481,14 @@ declare namespace ShopifyBuy {
     export interface ProductWithinVariant extends Pick<Product, "title" | "id">{}
 
     export interface Scalar {
+        value: string;
+    }
+
+    export interface Metafield {
+        id: string;
+        key: string;
+        namespace: string;
+        type: string;
         value: string;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/MetafieldFragment.graphql
+++ b/src/graphql/MetafieldFragment.graphql
@@ -1,0 +1,6 @@
+fragment MetafieldFragment on Metafield {
+    key
+    namespace
+    type
+    value
+}

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -12,6 +12,7 @@ fragment ProductFragment on Product {
   publishedAt
   onlineStoreUrl
   tags
+  quantity: totalInventory
   options {
     name
     values
@@ -43,5 +44,11 @@ fragment ProductFragment on Product {
         ...VariantWithProductFragment
       }
     }
+  }
+  metafields(identifiers: [
+    {namespace: "taiga", key: "preOrderStopCondition"},
+    {namespace: "taiga", key: "preOrderTimelineMessage"}
+  ]) {
+    ...MetafieldFragment
   }
 }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -37,4 +37,11 @@ fragment VariantFragment on ProductVariant {
     referenceUnit
     referenceValue
   }
+  metafields(identifiers: [
+    {namespace: "taiga", key: "preOrderStopCondition"},
+    {namespace: "taiga", key: "preOrderTimelineMessage"}
+  ]) {
+    ...MetafieldFragment
+  }
+  quantity: quantityAvailable
 }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1204168789439726/f

### Summary
This is a dependency of https://github.com/hellojuniper-com/juniper-react/pull/94. After merging, we must publish a new release version of this package, for `juniper-react` to consume.