### PR TITLE
[S/S Warehouse Pricing] Expose additional metafields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -475,10 +475,10 @@ declare namespace ShopifyBuy {
     }
 
     /**
-     * A subset of a product object that only includes the id and title. This exists in
-     * variants, so that they each have a reference back to their parent product node.
+     * A subset of a product object that only includes the id, title, and metafields. This
+     * exists in variants, so that they each have a reference back to their parent product node.
      */
-    export interface ProductWithinVariant extends Pick<Product, "title" | "id">{}
+    export interface ProductWithinVariant extends Pick<Product, "title" | "id" | "metafields">{}
 
     export interface Scalar {
         value: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -47,7 +47,7 @@ fragment ProductFragment on Product {
   }
   metafields(identifiers: [
     {namespace: "taiga", key: "preOrderStopCondition"},
-    {namespace: "taiga", key: "preOrderTimelineMessage"}
+    {namespace: "taiga", key: "preOrderDateEstimate"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -39,7 +39,7 @@ fragment VariantFragment on ProductVariant {
   }
   metafields(identifiers: [
     {namespace: "taiga", key: "preOrderStopCondition"},
-    {namespace: "taiga", key: "preOrderTimelineMessage"}
+    {namespace: "taiga", key: "preOrderDateEstimate"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -4,5 +4,11 @@ fragment VariantWithProductFragment on ProductVariant {
     id
     handle
     title
+    metafields(identifiers: [
+      {namespace: "taiga", key: "preOrderStopCondition"},
+      {namespace: "taiga", key: "preOrderDateEstimate"}
+    ]) {
+      ...MetafieldFragment
+    }
   }
 }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1204168789439716/f

### Summary

1. Added `metafields` GQL response field to the `ProductWithinVariant` so that clients can access a variant's associated product via `variant.product`.
2. Renamed the metafield `taiga.preOrderTimelineMessage` to `taiga.preOrderDateEstimate` (see [Shopify console definition](https://junipersales.myshopify.com/admin/settings/custom_data/productvariant/metafields/1120633023)) after making some tweaks with Torry on how we'll operationalize this data.
3. Bumped version to `2.16.3`