### PR TITLE
Update type definitions based on 2023-07 API version

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,6 +139,13 @@ declare namespace ShopifyBuy {
         reverse?: boolean | undefined;
     }
 
+    export type CurrencyCode = "GBP" | "EUR" | "USD" | "CAD";
+
+    export interface MoneyV2 {
+        amount: number;
+        currencyCode: CurrencyCode;
+    }
+
     export interface Product extends GraphModel {
         /**
          * A product description.
@@ -228,7 +235,7 @@ declare namespace ShopifyBuy {
          * Compare at price for variant. The compareAtPrice would be the price of the
          * product previously before the product went on sale.
          */
-        compareAtPrice: string;
+        compareAtPrice: MoneyV2;
 
         /**
          *  Indicates whether the variant is out of stock but still available for purchase (used
@@ -248,9 +255,9 @@ declare namespace ShopifyBuy {
         image: Image;
 
         /**
-         * Price of the variant. The price will be in the following form: "10.00"
+         * Price of the variant.
          */
-        price: string;
+        price: MoneyV2;
 
         /**
          * A limited reference to the variant's product.
@@ -334,7 +341,7 @@ declare namespace ShopifyBuy {
          * Example: two items have been added to the cart that cost $1.25 then the subtotal will be
          * 2.50
          */
-        subtotalPrice: string;
+        subtotalPrice: MoneyV2;
 
         /**
          * Get completed at date.


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1204990449692964/f

### Summary
The previous Shopify SDK version was wrapping the `2022-07` [Storefront API](https://shopify.dev/docs/api/storefront) version, which is now unsupported. Bumping up to `2023-07` requires a few minor schema changes, including the `MoneyV2` type (which replaces a legacy string representation of a product's dollar cost amount).

This PR itself is a no-op since the following still need to happen before a client can consume it:
1. A new release needs to be made, which will publish `@hellojuniper-com/shopify-buy@2.20.0` to the GitHub NPM registry.
2. `juniper-react` will need to bump up its dependency  `@hellojuniper-com/shopify-buy@2.20.0` and deployed to the Taiga infrastructure.

### Performed Testing
* Verified in `juniper-react` that the `2023-07` API version is being used in all GraphQL requests:

![Screenshot 2023-07-10 at 12 45 18 PM](https://github.com/hellojuniper-com/shopify-buy-sdk/assets/3443088/26a75dc9-2c55-4c49-90c8-0fabcf4d8c23)

* Verified that the new `MoneyV2` types match the GQL response schema
