### PR TITLE
Make compareAtPrice nullable and MoneyV2.amount a string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -142,7 +142,7 @@ declare namespace ShopifyBuy {
     export type CurrencyCode = "GBP" | "EUR" | "USD" | "CAD";
 
     export interface MoneyV2 {
-        amount: number;
+        amount: number | string;
         currencyCode: CurrencyCode;
     }
 
@@ -235,7 +235,7 @@ declare namespace ShopifyBuy {
          * Compare at price for variant. The compareAtPrice would be the price of the
          * product previously before the product went on sale.
          */
-        compareAtPrice: MoneyV2;
+        compareAtPrice: MoneyV2 | null;
 
         /**
          *  Indicates whether the variant is out of stock but still available for purchase (used

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1204990449692964/f

### Summary
The Storefront API documentation is a bunch of lies!!! [`MoneyV2.amount`](https://shopify.dev/docs/api/storefront/2023-07/objects/MoneyV2#field-moneyv2-amount) is supposed to be a `number` but instead, it shows up as a `string`, which is causing `NaN` to be rendered anywhere that there's a bundle price in the `juniper-react` app.

This is a minor type definition fix to make the `amount` a `number | string` and also makes `ProductVariant.compareAtPrice` nullable.

TODO: After merging into the `juniper-main` branch, a `2.20.1` release will be made, which will trigger an `npm publish` to the registry.

### Performed Testing
Verified that the type definitions are accurately reflected in `juniper-react` and `juniper-promo-commons`.
