### PR TITLE
Retrieving new `metafields` in GQL

### DIFF
--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -47,7 +47,17 @@ fragment ProductFragment on Product {
   }
   metafields(identifiers: [
     {namespace: "taiga", key: "preOrderStopCondition"},
-    {namespace: "taiga", key: "preOrderDateEstimate"}
+    {namespace: "taiga", key: "preOrderDateEstimate"},
+    {namespace: "productListing", key: "preOrderStopCondition"},
+    {namespace: "productListing", key: "launchType"},
+    {namespace: "productListing", key: "startingQuantity"},
+    {namespace: "productListing", key: "endingQuantity"},
+    {namespace: "productListing", key: "headline"},
+    {namespace: "productListing", key: "sizing"},
+    {namespace: "productListing", key: "campaignStart"},
+    {namespace: "productListing", key: "campaignEnd"},
+    {namespace: "productListing", key: "productionDuration"},
+    {namespace: "productListing", key: "hidden"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -55,7 +55,7 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "headline"},
     {namespace: "productListing", key: "sizing"},
     {namespace: "productListing", key: "campaignStart"},
-    {namespace: "productListing", key: "campaignEnd"},
+    {namespace: "productListing", key: "campaignDuration"},
     {namespace: "productListing", key: "productionDuration"},
     {namespace: "productListing", key: "hidden"}
   ]) {

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -54,7 +54,7 @@ fragment VariantFragment on ProductVariant {
     {namespace: "productListing", key: "headline"},
     {namespace: "productListing", key: "sizing"},
     {namespace: "productListing", key: "campaignStart"},
-    {namespace: "productListing", key: "campaignEnd"},
+    {namespace: "productListing", key: "campaignDuration"},
     {namespace: "productListing", key: "productionDuration"},
     {namespace: "productListing", key: "hidden"}
   ]) {

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -46,7 +46,17 @@ fragment VariantFragment on ProductVariant {
   }
   metafields(identifiers: [
     {namespace: "taiga", key: "preOrderStopCondition"},
-    {namespace: "taiga", key: "preOrderDateEstimate"}
+    {namespace: "taiga", key: "preOrderDateEstimate"},
+    {namespace: "productListing", key: "preOrderStopCondition"},
+    {namespace: "productListing", key: "launchType"},
+    {namespace: "productListing", key: "startingQuantity"},
+    {namespace: "productListing", key: "endingQuantity"},
+    {namespace: "productListing", key: "headline"},
+    {namespace: "productListing", key: "sizing"},
+    {namespace: "productListing", key: "campaignStart"},
+    {namespace: "productListing", key: "campaignEnd"},
+    {namespace: "productListing", key: "productionDuration"},
+    {namespace: "productListing", key: "hidden"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -14,7 +14,7 @@ fragment VariantWithProductFragment on ProductVariant {
       {namespace: "productListing", key: "headline"},
       {namespace: "productListing", key: "sizing"},
       {namespace: "productListing", key: "campaignStart"},
-      {namespace: "productListing", key: "campaignEnd"},
+      {namespace: "productListing", key: "campaignDuration"},
       {namespace: "productListing", key: "productionDuration"},
       {namespace: "productListing", key: "hidden"}
     ]) {

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -6,7 +6,17 @@ fragment VariantWithProductFragment on ProductVariant {
     title
     metafields(identifiers: [
       {namespace: "taiga", key: "preOrderStopCondition"},
-      {namespace: "taiga", key: "preOrderDateEstimate"}
+      {namespace: "taiga", key: "preOrderDateEstimate"},
+      {namespace: "productListing", key: "preOrderStopCondition"},
+      {namespace: "productListing", key: "launchType"},
+      {namespace: "productListing", key: "startingQuantity"},
+      {namespace: "productListing", key: "endingQuantity"},
+      {namespace: "productListing", key: "headline"},
+      {namespace: "productListing", key: "sizing"},
+      {namespace: "productListing", key: "campaignStart"},
+      {namespace: "productListing", key: "campaignEnd"},
+      {namespace: "productListing", key: "productionDuration"},
+      {namespace: "productListing", key: "hidden"}
     ]) {
       ...MetafieldFragment
     }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1205118259502492/f

### Summary
Added metafields for retrieval. Certain fields don't seem to be populated (only on the variant level), but I'm leaving them on for now for completeness.

Check fields here - https://docs.google.com/document/d/1Jn2NWuVh2BlokjsBIpk1IKg72bYAJDGPnR11dUqbNGc/edit

### Performed Testing
Verified that fields show up.
1. Sync the `juniperlaunch.com` website - `npm run sync -- -s juniperlaunch.com`
2. `THEME_FILE=juniperlaunch.com/v2 npm run start`
3. Check the products
4. Check GQL response for the metafields.

