### PR TITLE
Added reference to MetafieldFragment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/MetafieldFragment.graphql
+++ b/src/graphql/MetafieldFragment.graphql
@@ -3,4 +3,11 @@ fragment MetafieldFragment on Metafield {
     namespace
     type
     value
+    reference {
+        ... on MediaImage {
+            image {
+               originalSrc
+            }
+        }
+    }
 }

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -57,7 +57,8 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "campaignStart"},
     {namespace: "productListing", key: "campaignDuration"},
     {namespace: "productListing", key: "productionDuration"},
-    {namespace: "productListing", key: "hidden"}
+    {namespace: "productListing", key: "hidden"},
+    {namespace: "productListing", key: "banner"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -56,7 +56,8 @@ fragment VariantFragment on ProductVariant {
     {namespace: "productListing", key: "campaignStart"},
     {namespace: "productListing", key: "campaignDuration"},
     {namespace: "productListing", key: "productionDuration"},
-    {namespace: "productListing", key: "hidden"}
+    {namespace: "productListing", key: "hidden"},
+    {namespace: "productListing", key: "banner"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -16,7 +16,8 @@ fragment VariantWithProductFragment on ProductVariant {
       {namespace: "productListing", key: "campaignStart"},
       {namespace: "productListing", key: "campaignDuration"},
       {namespace: "productListing", key: "productionDuration"},
-      {namespace: "productListing", key: "hidden"}
+      {namespace: "productListing", key: "hidden"},
+      {namespace: "productListing", key: "banner"}
     ]) {
       ...MetafieldFragment
     }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1205340174026223/f

### Summary
Added a reference field that allows for one image to be the image banner for a website.

### Performed Testing
1. `yarn build`
2. `npm link @hellojuniper-com/shopify-buy`
3. `THEME_FILE=juniperlaunch.com/v2 npm run start`

Verify that it is included in the graphQL response.

```
{
   "id":"gid://shopify/Metafield/24860614820031",
   "key":"banner",
   "namespace":"productListing",
   "type":"file_reference",
   "value":"gid://shopify/MediaImage/27463891124415",
   "reference":{
      "id":"gid://shopify/MediaImage/27463891124415",
      "image":{
         "originalSrc":"https://cdn.shopify.com/s/files/1/1796/6745/files/channels4_banner.jpg?v=1693508114"
      }
   }
}
```
