### PR TITLE
Added multi-text metafield for details

### DIFF
--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -58,7 +58,8 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "campaignDuration"},
     {namespace: "productListing", key: "productionDuration"},
     {namespace: "productListing", key: "hidden"},
-    {namespace: "productListing", key: "banner"}
+    {namespace: "productListing", key: "banner"},
+    {namespace: "productListing", key: "details"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -57,7 +57,8 @@ fragment VariantFragment on ProductVariant {
     {namespace: "productListing", key: "campaignDuration"},
     {namespace: "productListing", key: "productionDuration"},
     {namespace: "productListing", key: "hidden"},
-    {namespace: "productListing", key: "banner"}
+    {namespace: "productListing", key: "banner"},
+    {namespace: "productListing", key: "details"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -18,7 +18,7 @@ fragment VariantWithProductFragment on ProductVariant {
       {namespace: "productListing", key: "productionDuration"},
       {namespace: "productListing", key: "hidden"},
       {namespace: "productListing", key: "banner"},
-      {namespace: "productListing", key: "details"},
+      {namespace: "productListing", key: "details"}
     ]) {
       ...MetafieldFragment
     }

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -17,7 +17,8 @@ fragment VariantWithProductFragment on ProductVariant {
       {namespace: "productListing", key: "campaignDuration"},
       {namespace: "productListing", key: "productionDuration"},
       {namespace: "productListing", key: "hidden"},
-      {namespace: "productListing", key: "banner"}
+      {namespace: "productListing", key: "banner"},
+      {namespace: "productListing", key: "details"},
     ]) {
       ...MetafieldFragment
     }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1205348286636961/f

### Summary
Added multi-text field for details. We will have to insert raw HTML into this multi-text field to achieve the same thing that we used to have.

### Performed Testing
Verified it shows up when investigating request on Juniper react.
1. `yarn build`
2. `npm link @hellojuniper-com/shopify-buy` in juniper-react.
3. Check graphql response for crowdfunded product.
