### PR TITLE
Added Elfsight Metafield

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.20.5",
+  "version": "2.20.6",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -64,7 +64,8 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "productVisibilityDate"},
     {namespace: "productListing", key: "overrideQuantity"},
     {namespace: "productListing", key: "holidayCardLink"},
-    {namespace: "productListing", key: "sizeGuide"}
+    {namespace: "productListing", key: "sizeGuide"},
+    {namespace: "productListing", key: "instagramId"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -65,7 +65,7 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "overrideQuantity"},
     {namespace: "productListing", key: "holidayCardLink"},
     {namespace: "productListing", key: "sizeGuide"},
-    {namespace: "productListing", key: "instagramId"}
+    {namespace: "productListing", key: "elfsightInstagramId"}
   ]) {
     ...MetafieldFragment
   }


### PR DESCRIPTION
This change aims to add the Elfsight Instagram Id Metafield for consumption by the juniper-react package. 

Testing:

To verify, just do the following:

1. `yarn build`
2. `npm link @hellojuniper-com/shopify-buy`
3. `THEME_FILE=juniperlaunch.com/v2 npm run start`

Verify that the GQL response has the instagram id. It should be in the crowdfunded product.