### PR TITLE
Added metafields needed for collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.20.7",
+  "version": "2.20.8",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragmentSimplified.graphql
+++ b/src/graphql/ProductFragmentSimplified.graphql
@@ -48,6 +48,13 @@ fragment ProductFragmentSimplified on Product {
   metafields(identifiers: [
     {namespace: "taiga", key: "preOrderStopCondition"},
     {namespace: "taiga", key: "preOrderDateEstimate"},
+    {namespace: "productListing", key: "launchType"},
+    {namespace: "productListing", key: "orderType"},
+    {namespace: "productListing", key: "startingQuantity"},
+    {namespace: "productListing", key: "endingQuantity"},
+    {namespace: "productListing", key: "campaignStart"},
+    {namespace: "productListing", key: "campaignEnd"},
+    {namespace: "productListing", key: "overrideQuantity"},
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -7,6 +7,8 @@ fragment VariantWithProductFragment on ProductVariant {
     metafields(identifiers: [
       {namespace: "taiga", key: "preOrderStopCondition"},
       {namespace: "taiga", key: "preOrderDateEstimate"},
+      {namespace: "productListing", key: "startingQuantity"},
+      {namespace: "productListing", key: "endingQuantity"}
     ]) {
       ...MetafieldFragment
     }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1205825555304774/f

### Summary
Needed to add back fields that are needed to calculate the product level `CampaignProgressView` information in the collection. Specifically they were:
```
    {namespace: "productListing", key: "launchType"},
    {namespace: "productListing", key: "orderType"},
    {namespace: "productListing", key: "startingQuantity"},
    {namespace: "productListing", key: "endingQuantity"},
    {namespace: "productListing", key: "campaignStart"},
    {namespace: "productListing", key: "campaignEnd"},
    {namespace: "productListing", key: "overrideQuantity"},
```

I've also added back fields that will be useful at the variant level later on.

### Performed Testing
Verified visually.