### PR TITLE
Added extra fundraiser metafields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.20.9",
+  "version": "2.20.10",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -69,7 +69,8 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "detailsJson"},
     {namespace: "productListing", key: "organizationName"},
     {namespace: "productListing", key: "organizationDescription"},
-    {namespace: "productListing", key: "organizationLink"}
+    {namespace: "productListing", key: "organizationLink"},
+    {namespace: "productListing", key: "fundraiserGoal"}
   ]) {
     ...MetafieldFragment
   }

--- a/src/graphql/ProductFragmentSimplified.graphql
+++ b/src/graphql/ProductFragmentSimplified.graphql
@@ -33,7 +33,7 @@ fragment ProductFragmentSimplified on Product {
       }
     }
   }
-  variants(first: 1) {
+  variants(first: 250) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -55,6 +55,7 @@ fragment ProductFragmentSimplified on Product {
     {namespace: "productListing", key: "campaignStart"},
     {namespace: "productListing", key: "campaignEnd"},
     {namespace: "productListing", key: "overrideQuantity"},
+    {namespace: "productListing", key: "fundraiserGoal"}
   ]) {
     ...MetafieldFragment
   }


### PR DESCRIPTION
### Asana Task
None

### Summary
After discussion with Nicholas, we realized we needed one more metafield for the `fundraiserGoal` which is the fundraiser amount we are trying to meet. However, to display the progress bar on the collection view, we also need to be able to calculate the current amount fundraised. The process for calculating that is as follows:

1. Get every variant on the product
2. Calculate `sum(donationAmount * # variant sold)`

We then use that to display the progress bar properly. To do that, we'll have to retrieve all variants. I think this will be fine for our collection query optimization, but we may need to actually optimize this in the future with:

1. Given the launch type, retrieve a certain amount of variants to prevent needing all of them.

### Performed Testing
Verified it works.
