### PR TITLE
Add `VariantFragmentSimplified` for Collection View

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.20.12",
+  "version": "2.20.13",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragmentSimplified.graphql
+++ b/src/graphql/ProductFragmentSimplified.graphql
@@ -1,16 +1,8 @@
 fragment ProductFragmentSimplified on Product {
   id
-  availableForSale
-  createdAt
-  updatedAt
-  descriptionHtml
-  description
   handle
-  productType
   title
   vendor
-  publishedAt
-  onlineStoreUrl
   tags
   quantity: totalInventory
   options {
@@ -33,7 +25,7 @@ fragment ProductFragmentSimplified on Product {
       }
     }
   }
-  variants(first: 1) {
+  variants(first: 250) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -41,7 +33,7 @@ fragment ProductFragmentSimplified on Product {
     edges {
       cursor
       node {
-        ...VariantWithProductFragment
+        ...VariantWithProductFragmentSimplified
       }
     }
   }

--- a/src/graphql/VariantFragmentSimplified.graphql
+++ b/src/graphql/VariantFragmentSimplified.graphql
@@ -32,7 +32,6 @@ fragment VariantFragmentSimplified on ProductVariant {
       { namespace: "productListing", key: "startingQuantity" },
       { namespace: "productListing", key: "endingQuantity" },
       { namespace: "productListing", key: "donationAmount" },
-      { namespace: "productListing", key: "timelineTextAddition" }
     ]
   ) {
     ...MetafieldFragment

--- a/src/graphql/VariantFragmentSimplified.graphql
+++ b/src/graphql/VariantFragmentSimplified.graphql
@@ -1,0 +1,41 @@
+fragment VariantFragmentSimplified on ProductVariant {
+  id
+  title
+  price {
+    amount
+    currencyCode
+  }
+  priceV2: price {
+    amount
+    currencyCode
+  }
+  available: availableForSale
+  compareAtPrice {
+    amount
+    currencyCode
+  }
+  compareAtPriceV2: compareAtPrice {
+    amount
+    currencyCode
+  }
+  image {
+    id
+    src: url
+    altText
+    width
+    height
+  }
+  metafields(
+    identifiers: [
+      { namespace: "taiga", key: "preOrderStopCondition" },
+      { namespace: "taiga", key: "preOrderDateEstimate" },
+      { namespace: "productListing", key: "startingQuantity" },
+      { namespace: "productListing", key: "endingQuantity" },
+      { namespace: "productListing", key: "donationAmount" },
+      { namespace: "productListing", key: "timelineTextAddition" }
+    ]
+  ) {
+    ...MetafieldFragment
+  }
+  quantity: quantityAvailable
+}

--- a/src/graphql/VariantWithProductFragmentSimplified.graphql
+++ b/src/graphql/VariantWithProductFragmentSimplified.graphql
@@ -1,0 +1,14 @@
+fragment VariantWithProductFragmentSimplified on ProductVariant {
+  ...VariantFragmentSimplified
+  product {
+    id
+    handle
+    title
+    metafields(identifiers: [
+      {namespace: "taiga", key: "preOrderStopCondition"},
+      {namespace: "taiga", key: "preOrderDateEstimate"},
+    ]) {
+      ...MetafieldFragment
+    }
+  }
+}


### PR DESCRIPTION
### Asana Task
None

### Summary
Due to recurring issues with only having a single variant, especially with the collection view, I've decided to keep all variants and simplify the response to a good size. I essentially rip out all non-important data on the variant level here and just keep pricing + quantity + availability information.

### Performed Testing
Verified visually with `THEME_FILE=juniperlaunch.com/v3 npm run start` and with a large collection.
