### PR TITLE
Added processing time and removed irrelevant quantities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.21.4",
+  "version": "2.21.5",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -51,8 +51,6 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "preOrderStopCondition"},
     {namespace: "productListing", key: "launchType"},
     {namespace: "productListing", key: "orderType"},
-    {namespace: "productListing", key: "startingQuantity"},
-    {namespace: "productListing", key: "endingQuantity"},
     {namespace: "productListing", key: "headline"},
     {namespace: "productListing", key: "sizing"},
     {namespace: "productListing", key: "campaignStart"},
@@ -74,7 +72,8 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "storeId"},
     {namespace: "productListing", key: "hideBannerProductName"},
     {namespace: "productListing", key: "targetQuantity"},
-    {namespace: "productListing", key: "fundraisedAmount"}
+    {namespace: "productListing", key: "fundraisedAmount"},
+    {namespace: "productListing", key: "processingTime"}
   ]) {
     ...MetafieldWithReferenceFragment
   }

--- a/src/graphql/ProductFragmentSimplified.graphql
+++ b/src/graphql/ProductFragmentSimplified.graphql
@@ -42,8 +42,6 @@ fragment ProductFragmentSimplified on Product {
     {namespace: "taiga", key: "preOrderDateEstimate"},
     {namespace: "productListing", key: "launchType"},
     {namespace: "productListing", key: "orderType"},
-    {namespace: "productListing", key: "startingQuantity"},
-    {namespace: "productListing", key: "endingQuantity"},
     {namespace: "productListing", key: "campaignStart"},
     {namespace: "productListing", key: "campaignEnd"},
     {namespace: "productListing", key: "overrideQuantity"},


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202051573875308/1206941143068125/f

### Summary
Removed `startingQuantity` and `endingQuantity` metafields since we no longer need them. 

### Performed Testing
Verified that the new `processingTime` metafield is showing up.

`yarn build`
`npm link @hellojuniper-com/shopify-buy` on juniper-react
verify response:


```
                {
                    "id": "gid://shopify/Metafield/25425964695743",
                    "key": "fundraiserGoal",
                    "namespace": "productListing",
                    "type": "number_integer",
                    "value": "3000",
                    "reference": null
                },
                null,
                null,
                {
                    "id": "gid://shopify/Metafield/27124458455231",
                    "key": "targetQuantity",
                    "namespace": "productListing",
                    "type": "number_integer",
                    "value": "300",
                    "reference": null
                },
                null,
                {
                    "id": "gid://shopify/Metafield/27342235304127",
                    "key": "processingTime",
                    "namespace": "productListing",
                    "type": "single_line_text_field",
                    "value": "1 - 5 days",
                    "reference": null
                }
            ],
```