### PR TITLE
Changed to `metafieldsWithReference`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.21.5",
+  "version": "2.21.6",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/VariantFragmentSimplified.graphql
+++ b/src/graphql/VariantFragmentSimplified.graphql
@@ -25,8 +25,7 @@ fragment VariantFragmentSimplified on ProductVariant {
     width
     height
   }
-  metafields(
-    identifiers: [
+  metafieldsWithReference: metafields(identifiers: [
       { namespace: "taiga", key: "preOrderStopCondition" },
       { namespace: "taiga", key: "preOrderDateEstimate" },
       { namespace: "productListing", key: "startingQuantity" },


### PR DESCRIPTION
### Asana Task
None

### Summary
The metafields on collections were not properly named `metafieldsWithReference` which caused the search function to fail on `getMetafieldFromObject` on juniper-react.

### Performed Testing
`npm run build`
`npm link @hellojuniper-com/shopify-buy` in juniper-react and saw that the reversible kiwi plush on eggdog.shop is showing out of stock as expected.
