### PR TITLE
Add support for `liveStatus` product metafield

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.21.8",
+  "version": "2.21.9",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -86,7 +86,8 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "hideBannerProductName"},
     {namespace: "productListing", key: "targetQuantity"},
     {namespace: "productListing", key: "fundraisedAmount"},
-    {namespace: "productListing", key: "processingTime"}
+    {namespace: "productListing", key: "processingTime"},
+    {namespace: "productListing", key: "liveStatus"},
   ]) {
     ...MetafieldWithReferenceFragment
   }

--- a/src/graphql/ProductFragmentSimplified.graphql
+++ b/src/graphql/ProductFragmentSimplified.graphql
@@ -48,7 +48,8 @@ fragment ProductFragmentSimplified on Product {
     {namespace: "productListing", key: "fundraiserGoal"},
     {namespace: "productListing", key: "storeId"},
     {namespace: "productListing", key: "targetQuantity"},
-    {namespace: "productListing", key: "fundraisedAmount"}
+    {namespace: "productListing", key: "fundraisedAmount"},
+    {namespace: "productListing", key: "liveStatus"},
   ]) {
     ...MetafieldWithReferenceFragment
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,21 +3,21 @@
 
 
 "@babel/code-frame@^7.14.5":
-  "integrity" "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw=="
-  "resolved" "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
   dependencies:
     "@babel/highlight" "^7.14.5"
 
 "@babel/compat-data@^7.15.0":
-  "integrity" "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA=="
-  "resolved" "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz"
+  integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.0":
-  "integrity" "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw=="
-  "resolved" "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz"
-  "version" "7.15.0"
+"@babel/core@^7.1.0":
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz"
+  integrity sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==
   dependencies:
     "@babel/code-frame" "^7.14.5"
     "@babel/generator" "^7.15.0"
@@ -28,73 +28,73 @@
     "@babel/template" "^7.14.5"
     "@babel/traverse" "^7.15.0"
     "@babel/types" "^7.15.0"
-    "convert-source-map" "^1.7.0"
-    "debug" "^4.1.0"
-    "gensync" "^1.0.0-beta.2"
-    "json5" "^2.1.2"
-    "semver" "^6.3.0"
-    "source-map" "^0.5.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
 
 "@babel/generator@^7.15.0":
-  "integrity" "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ=="
-  "resolved" "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz"
+  integrity sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==
   dependencies:
     "@babel/types" "^7.15.0"
-    "jsesc" "^2.5.1"
-    "source-map" "^0.5.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
 
 "@babel/helper-compilation-targets@^7.15.0":
-  "integrity" "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz"
+  integrity sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==
   dependencies:
     "@babel/compat-data" "^7.15.0"
     "@babel/helper-validator-option" "^7.14.5"
-    "browserslist" "^4.16.6"
-    "semver" "^6.3.0"
+    browserslist "^4.16.6"
+    semver "^6.3.0"
 
 "@babel/helper-function-name@^7.14.5":
-  "integrity" "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz"
+  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
   dependencies:
     "@babel/helper-get-function-arity" "^7.14.5"
     "@babel/template" "^7.14.5"
     "@babel/types" "^7.14.5"
 
 "@babel/helper-get-function-arity@^7.14.5":
-  "integrity" "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz"
+  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
   dependencies:
     "@babel/types" "^7.14.5"
 
 "@babel/helper-hoist-variables@^7.14.5":
-  "integrity" "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz"
+  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
   dependencies:
     "@babel/types" "^7.14.5"
 
 "@babel/helper-member-expression-to-functions@^7.15.0":
-  "integrity" "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz"
+  integrity sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==
   dependencies:
     "@babel/types" "^7.15.0"
 
 "@babel/helper-module-imports@^7.14.5":
-  "integrity" "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz"
+  integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
   dependencies:
     "@babel/types" "^7.14.5"
 
 "@babel/helper-module-transforms@^7.15.0":
-  "integrity" "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz"
+  integrity sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==
   dependencies:
     "@babel/helper-module-imports" "^7.14.5"
     "@babel/helper-replace-supers" "^7.15.0"
@@ -106,16 +106,16 @@
     "@babel/types" "^7.15.0"
 
 "@babel/helper-optimise-call-expression@^7.14.5":
-  "integrity" "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz"
+  integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
   dependencies:
     "@babel/types" "^7.14.5"
 
 "@babel/helper-replace-supers@^7.15.0":
-  "integrity" "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz"
+  integrity sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==
   dependencies:
     "@babel/helper-member-expression-to-functions" "^7.15.0"
     "@babel/helper-optimise-call-expression" "^7.14.5"
@@ -123,70 +123,70 @@
     "@babel/types" "^7.15.0"
 
 "@babel/helper-simple-access@^7.14.8":
-  "integrity" "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz"
-  "version" "7.14.8"
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz"
+  integrity sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==
   dependencies:
     "@babel/types" "^7.14.8"
 
 "@babel/helper-split-export-declaration@^7.14.5":
-  "integrity" "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz"
+  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
   dependencies:
     "@babel/types" "^7.14.5"
 
 "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
-  "integrity" "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz"
-  "version" "7.14.9"
+  version "7.14.9"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz"
+  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
 
 "@babel/helper-validator-option@^7.14.5":
-  "integrity" "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
-  "resolved" "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
 "@babel/helpers@^7.14.8":
-  "integrity" "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g=="
-  "resolved" "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz"
-  "version" "7.15.3"
+  version "7.15.3"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz"
+  integrity sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==
   dependencies:
     "@babel/template" "^7.14.5"
     "@babel/traverse" "^7.15.0"
     "@babel/types" "^7.15.0"
 
 "@babel/highlight@^7.14.5":
-  "integrity" "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg=="
-  "resolved" "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
-    "chalk" "^2.0.0"
-    "js-tokens" "^4.0.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
 
 "@babel/parser@^7.14.5", "@babel/parser@^7.15.0":
-  "integrity" "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA=="
-  "resolved" "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz"
-  "version" "7.15.3"
+  version "7.15.3"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz"
+  integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
 
 "@babel/parser@^7.4.4":
-  "integrity" "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
-  "resolved" "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz"
-  "version" "7.5.5"
+  version "7.5.5"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz"
+  integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
 
 "@babel/template@^7.14.5":
-  "integrity" "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g=="
-  "resolved" "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz"
-  "version" "7.14.5"
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
   dependencies:
     "@babel/code-frame" "^7.14.5"
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
 "@babel/traverse@^7.15.0":
-  "integrity" "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw=="
-  "resolved" "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz"
+  integrity sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==
   dependencies:
     "@babel/code-frame" "^7.14.5"
     "@babel/generator" "^7.15.0"
@@ -195,7877 +195,7729 @@
     "@babel/helper-split-export-declaration" "^7.14.5"
     "@babel/parser" "^7.15.0"
     "@babel/types" "^7.15.0"
-    "debug" "^4.1.0"
-    "globals" "^11.1.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
 
 "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.15.0":
-  "integrity" "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ=="
-  "resolved" "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz"
-  "version" "7.15.0"
+  version "7.15.0"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz"
+  integrity sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.9"
-    "to-fast-properties" "^2.0.0"
+    to-fast-properties "^2.0.0"
 
-"abstract-leveldown@~0.12.0", "abstract-leveldown@~0.12.1":
-  "integrity" "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA="
-  "resolved" "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz"
-  "version" "0.12.4"
+abstract-leveldown@~0.12.0, abstract-leveldown@~0.12.1:
+  version "0.12.4"
+  resolved "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz"
+  integrity sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=
   dependencies:
-    "xtend" "~3.0.0"
+    xtend "~3.0.0"
 
-"acorn-jsx@^3.0.0":
-  "integrity" "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s="
-  "resolved" "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
-  "version" "3.0.1"
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
   dependencies:
-    "acorn" "^3.0.4"
+    acorn "^3.0.4"
 
-"acorn@^3.0.4":
-  "integrity" "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-  "resolved" "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-  "version" "3.3.0"
+acorn@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz"
+  integrity sha1-F6jWp6bE71OLgU7Jq6wneSk78wo=
 
-"acorn@^4.0.1":
-  "integrity" "sha1-7c2jvZN+dVZBDULtWGD2c5nHlMA="
-  "resolved" "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
-  "version" "4.0.11"
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-"acorn@4.0.4":
-  "integrity" "sha1-F6jWp6bE71OLgU7Jq6wneSk78wo="
-  "resolved" "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz"
-  "version" "4.0.4"
+acorn@^4.0.1:
+  version "4.0.11"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
+  integrity sha1-7c2jvZN+dVZBDULtWGD2c5nHlMA=
 
-"ajv-keywords@^1.0.0":
-  "integrity" "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-  "resolved" "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
-  "version" "1.5.1"
+ajv-keywords@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
+  integrity sha1-MU3QpLM2j609/NxU7eYXG4htrzw=
 
-"ajv@^4.7.0", "ajv@>=4.10.0":
-  "integrity" "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0="
-  "resolved" "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz"
-  "version" "4.11.5"
+ajv@^4.7.0:
+  version "4.11.5"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz"
+  integrity sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=
   dependencies:
-    "co" "^4.6.0"
-    "json-stable-stringify" "^1.0.1"
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
 
-"ajv@^4.9.1":
-  "integrity" "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
-  "resolved" "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
-  "version" "4.11.8"
+ajv@^4.9.1:
+  version "4.11.8"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
   dependencies:
-    "co" "^4.6.0"
-    "json-stable-stringify" "^1.0.1"
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
 
-"ansi-escape-sequences@^3.0.0":
-  "integrity" "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4="
-  "resolved" "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz"
-  "version" "3.0.0"
+ansi-escape-sequences@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz"
+  integrity sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=
   dependencies:
-    "array-back" "^1.0.3"
+    array-back "^1.0.3"
 
-"ansi-escape-sequences@^4.0.0":
-  "integrity" "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw=="
-  "resolved" "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz"
-  "version" "4.1.0"
+ansi-escape-sequences@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz"
+  integrity sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==
   dependencies:
-    "array-back" "^3.0.1"
+    array-back "^3.0.1"
 
-"ansi-escapes@^1.1.0":
-  "integrity" "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-  "resolved" "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-  "version" "1.4.0"
+ansi-escapes@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+  integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
 
-"ansi-regex@^0.2.0", "ansi-regex@^0.2.1":
-  "integrity" "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-  "resolved" "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-  "version" "0.2.1"
+ansi-regex@^0.2.0, ansi-regex@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+  integrity sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=
 
-"ansi-regex@^2.0.0":
-  "integrity" "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-  "resolved" "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-  "version" "2.1.1"
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
-"ansi-styles@^1.1.0":
-  "integrity" "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-  "resolved" "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-  "version" "1.1.0"
+ansi-styles@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+  integrity sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=
 
-"ansi-styles@^2.2.1":
-  "integrity" "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-  "resolved" "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-  "version" "2.2.1"
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-"ansi-styles@^3.2.1":
-  "integrity" "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="
-  "resolved" "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
-  "version" "3.2.1"
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
-    "color-convert" "^1.9.0"
+    color-convert "^1.9.0"
 
-"anymatch@^1.3.0":
-  "integrity" "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA=="
-  "resolved" "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz"
-  "version" "1.3.2"
+anymatch@^1.3.0:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz"
+  integrity sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==
   dependencies:
-    "micromatch" "^2.1.5"
-    "normalize-path" "^2.0.0"
+    micromatch "^2.1.5"
+    normalize-path "^2.0.0"
 
-"archive-type@^3.0.0", "archive-type@^3.0.1":
-  "integrity" "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y="
-  "resolved" "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz"
-  "version" "3.2.0"
+archive-type@^3.0.0, archive-type@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz"
+  integrity sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=
   dependencies:
-    "file-type" "^3.1.0"
+    file-type "^3.1.0"
 
-"argparse@^1.0.7":
-  "integrity" "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
-  "resolved" "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
-  "version" "1.0.9"
+argparse@^1.0.7:
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
+  integrity sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=
   dependencies:
-    "sprintf-js" "~1.0.2"
+    sprintf-js "~1.0.2"
 
-"arr-diff@^2.0.0":
-  "integrity" "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8="
-  "resolved" "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-  "version" "2.0.0"
+arr-diff@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+  integrity sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=
   dependencies:
-    "arr-flatten" "^1.0.1"
+    arr-flatten "^1.0.1"
 
-"arr-diff@^4.0.0":
-  "integrity" "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-  "resolved" "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz"
-  "version" "4.0.0"
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz"
+  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
-"arr-flatten@^1.0.1", "arr-flatten@^1.1.0":
-  "integrity" "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-  "resolved" "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
-  "version" "1.1.0"
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
 
-"arr-union@^3.1.0":
-  "integrity" "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-  "resolved" "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz"
-  "version" "3.1.0"
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-"array-back@^1.0.2", "array-back@^1.0.3", "array-back@^1.0.4":
-  "integrity" "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs="
-  "resolved" "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz"
-  "version" "1.0.4"
+array-back@^1.0.2, array-back@^1.0.3, array-back@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz"
+  integrity sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=
   dependencies:
-    "typical" "^2.6.0"
+    typical "^2.6.0"
 
-"array-back@^2.0.0":
-  "integrity" "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw=="
-  "resolved" "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz"
-  "version" "2.0.0"
+array-back@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz"
+  integrity sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==
   dependencies:
-    "typical" "^2.6.1"
+    typical "^2.6.1"
 
-"array-back@^3.0.1":
-  "integrity" "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
-  "resolved" "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz"
-  "version" "3.1.0"
+array-back@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
 
-"array-back@^4.0.0":
-  "integrity" "sha512-ylVYjv5BzoWXWO7e6fWrzjqzgxmUPWdQrHxgzo/v1EaYXfw6+6ipRdIr7KryAGnVHG08O1Yfpchuv0+YhjPL+Q=="
-  "resolved" "https://registry.npmjs.org/array-back/-/array-back-4.0.0.tgz"
-  "version" "4.0.0"
+array-back@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-4.0.0.tgz"
+  integrity sha512-ylVYjv5BzoWXWO7e6fWrzjqzgxmUPWdQrHxgzo/v1EaYXfw6+6ipRdIr7KryAGnVHG08O1Yfpchuv0+YhjPL+Q==
 
-"array-differ@^1.0.0":
-  "integrity" "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-  "resolved" "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-  "version" "1.0.0"
+array-differ@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+  integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
 
-"array-union@^1.0.1":
-  "integrity" "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk="
-  "resolved" "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
-  "version" "1.0.2"
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
   dependencies:
-    "array-uniq" "^1.0.1"
+    array-uniq "^1.0.1"
 
-"array-uniq@^1.0.1", "array-uniq@^1.0.2":
-  "integrity" "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-  "resolved" "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-  "version" "1.0.3"
+array-uniq@^1.0.1, array-uniq@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-"array-unique@^0.2.1":
-  "integrity" "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-  "resolved" "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-  "version" "0.2.1"
+array-unique@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+  integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
 
-"array-unique@^0.3.2":
-  "integrity" "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-  "resolved" "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz"
-  "version" "0.3.2"
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz"
+  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-"arrify@^1.0.0", "arrify@^1.0.1":
-  "integrity" "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-  "resolved" "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-  "version" "1.0.1"
+arrify@^1.0.0, arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-"asn1.js@^4.0.0":
-  "integrity" "sha1-SLokC0WpKA6UdImQull9IWYX/UA="
-  "resolved" "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz"
-  "version" "4.9.1"
+asn1.js@^4.0.0:
+  version "4.9.1"
+  resolved "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz"
+  integrity sha1-SLokC0WpKA6UdImQull9IWYX/UA=
   dependencies:
-    "bn.js" "^4.0.0"
-    "inherits" "^2.0.1"
-    "minimalistic-assert" "^1.0.0"
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
 
-"asn1@~0.2.3":
-  "integrity" "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg=="
-  "resolved" "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz"
-  "version" "0.2.4"
+asn1@0.1.11:
+  version "0.1.11"
+  resolved "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+  integrity sha1-VZvhg3bQik7E2+gId9J4GGObLfc=
+
+asn1@~0.2.3:
+  version "0.2.4"
+  resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz"
+  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
-    "safer-buffer" "~2.1.0"
+    safer-buffer "~2.1.0"
 
-"asn1@0.1.11":
-  "integrity" "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
-  "resolved" "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-  "version" "0.1.11"
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-"assert-plus@^0.1.5":
-  "integrity" "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
-  "resolved" "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-  "version" "0.1.5"
+assert-plus@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+  integrity sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=
 
-"assert-plus@^0.2.0":
-  "integrity" "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-  "resolved" "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-  "version" "0.2.0"
+assert-plus@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+  integrity sha1-104bh+ev/A24qttwIfP+SBAasjQ=
 
-"assert-plus@^1.0.0", "assert-plus@1.0.0":
-  "integrity" "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-  "resolved" "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-  "version" "1.0.0"
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
+  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-"assign-symbols@^1.0.0":
-  "integrity" "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-  "resolved" "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
-  "version" "1.0.0"
+async-array-reduce@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz"
+  integrity sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE=
 
-"async-array-reduce@^0.2.0":
-  "integrity" "sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE="
-  "resolved" "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz"
-  "version" "0.2.1"
+async-each-series@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz"
+  integrity sha1-9C/YFV048hpbjqB8KOBj7RcAsTg=
 
-"async-each-series@^1.1.0":
-  "integrity" "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg="
-  "resolved" "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz"
-  "version" "1.1.0"
+async-each@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+  integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
 
-"async-each@^1.0.0":
-  "integrity" "sha1-GdOGodntxufByF04iu28xW0zYC0="
-  "resolved" "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
-  "version" "1.0.1"
+async@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
+  integrity sha1-pIFqF81f9RbfosdpikUzabl5DeA=
 
-"async@^1.5.2":
-  "integrity" "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-  "resolved" "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-  "version" "1.5.2"
+async@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-"async@~0.9.0":
-  "integrity" "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
-  "resolved" "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-  "version" "0.9.0"
+async@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+  integrity sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc=
 
-"async@1.2.1":
-  "integrity" "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
-  "resolved" "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
-  "version" "1.2.1"
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-"asynckit@^0.4.0":
-  "integrity" "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-  "resolved" "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-  "version" "0.4.0"
+atob@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-"atob@^2.1.1":
-  "integrity" "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-  "resolved" "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz"
-  "version" "2.1.2"
-
-"aws-sdk@2.162.0":
-  "integrity" "sha1-GxYhX8m1mbp80s/nzgUMf5NDgaY="
-  "resolved" "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.162.0.tgz"
-  "version" "2.162.0"
+aws-sdk@2.162.0:
+  version "2.162.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.162.0.tgz"
+  integrity sha1-GxYhX8m1mbp80s/nzgUMf5NDgaY=
   dependencies:
-    "buffer" "4.9.1"
-    "crypto-browserify" "1.0.9"
-    "events" "^1.1.1"
-    "jmespath" "0.15.0"
-    "querystring" "0.2.0"
-    "sax" "1.2.1"
-    "url" "0.10.3"
-    "uuid" "3.1.0"
-    "xml2js" "0.4.17"
-    "xmlbuilder" "4.2.1"
+    buffer "4.9.1"
+    crypto-browserify "1.0.9"
+    events "^1.1.1"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.17"
+    xmlbuilder "4.2.1"
 
-"aws-sign2@~0.5.0":
-  "integrity" "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
-  "resolved" "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-  "version" "0.5.0"
+aws-sign2@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+  integrity sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=
 
-"aws-sign2@~0.6.0":
-  "integrity" "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-  "resolved" "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-  "version" "0.6.0"
+aws-sign2@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+  integrity sha1-FDQt0428yU0OW4fXY81jYSwOeU8=
 
-"aws4@^1.2.1":
-  "integrity" "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-  "resolved" "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
-  "version" "1.8.0"
+aws4@^1.2.1:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-"babel-code-frame@^6.22.0":
-  "integrity" "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
-  "resolved" "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
-  "version" "6.22.0"
+babel-code-frame@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
+  integrity sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=
   dependencies:
-    "chalk" "^1.1.0"
-    "esutils" "^2.0.2"
-    "js-tokens" "^3.0.0"
+    chalk "^1.1.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
 
-"babel-code-frame@^6.26.0":
-  "integrity" "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s="
-  "resolved" "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz"
-  "version" "6.26.0"
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz"
+  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
   dependencies:
-    "chalk" "^1.1.3"
-    "esutils" "^2.0.2"
-    "js-tokens" "^3.0.2"
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
 
-"babel-core@^6.26.0", "babel-core@6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc", "babel-core@6.26.0":
-  "integrity" "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g="
-  "resolved" "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz"
-  "version" "6.26.0"
+babel-core@6.26.0, babel-core@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz"
+  integrity sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=
   dependencies:
-    "babel-code-frame" "^6.26.0"
-    "babel-generator" "^6.26.0"
-    "babel-helpers" "^6.24.1"
-    "babel-messages" "^6.23.0"
-    "babel-register" "^6.26.0"
-    "babel-runtime" "^6.26.0"
-    "babel-template" "^6.26.0"
-    "babel-traverse" "^6.26.0"
-    "babel-types" "^6.26.0"
-    "babylon" "^6.18.0"
-    "convert-source-map" "^1.5.0"
-    "debug" "^2.6.8"
-    "json5" "^0.5.1"
-    "lodash" "^4.17.4"
-    "minimatch" "^3.0.4"
-    "path-is-absolute" "^1.0.1"
-    "private" "^0.1.7"
-    "slash" "^1.0.0"
-    "source-map" "^0.5.6"
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.0"
+    debug "^2.6.8"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.7"
+    slash "^1.0.0"
+    source-map "^0.5.6"
 
-"babel-eslint@6.1.x":
-  "integrity" "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8="
-  "resolved" "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz"
-  "version" "6.1.2"
+babel-eslint@6.1.x:
+  version "6.1.2"
+  resolved "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz"
+  integrity sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=
   dependencies:
-    "babel-traverse" "^6.0.20"
-    "babel-types" "^6.0.19"
-    "babylon" "^6.0.18"
-    "lodash.assign" "^4.0.0"
-    "lodash.pickby" "^4.0.0"
+    babel-traverse "^6.0.20"
+    babel-types "^6.0.19"
+    babylon "^6.0.18"
+    lodash.assign "^4.0.0"
+    lodash.pickby "^4.0.0"
 
-"babel-generator@^6.26.0":
-  "integrity" "sha1-rBriAHC3n248odMmlhMFN3TyDcU="
-  "resolved" "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz"
-  "version" "6.26.0"
+babel-generator@6.16.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.16.0.tgz"
+  integrity sha1-LDjuYmma3OJl8KMs4YosIc8Pyng=
   dependencies:
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.26.0"
-    "babel-types" "^6.26.0"
-    "detect-indent" "^4.0.0"
-    "jsesc" "^1.3.0"
-    "lodash" "^4.17.4"
-    "source-map" "^0.5.6"
-    "trim-right" "^1.0.1"
+    babel-messages "^6.8.0"
+    babel-runtime "^6.9.0"
+    babel-types "^6.16.0"
+    detect-indent "^3.0.1"
+    jsesc "^1.3.0"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
 
-"babel-generator@6.16.0":
-  "integrity" "sha1-LDjuYmma3OJl8KMs4YosIc8Pyng="
-  "resolved" "https://registry.npmjs.org/babel-generator/-/babel-generator-6.16.0.tgz"
-  "version" "6.16.0"
+babel-generator@6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz"
+  integrity sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=
   dependencies:
-    "babel-messages" "^6.8.0"
-    "babel-runtime" "^6.9.0"
-    "babel-types" "^6.16.0"
-    "detect-indent" "^3.0.1"
-    "jsesc" "^1.3.0"
-    "lodash" "^4.2.0"
-    "source-map" "^0.5.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
 
-"babel-generator@6.24.1":
-  "integrity" "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc="
-  "resolved" "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz"
-  "version" "6.24.1"
+babel-generator@6.25.0:
+  version "6.25.0"
+  resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz"
+  integrity sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=
   dependencies:
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.24.1"
-    "detect-indent" "^4.0.0"
-    "jsesc" "^1.3.0"
-    "lodash" "^4.2.0"
-    "source-map" "^0.5.0"
-    "trim-right" "^1.0.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.25.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
 
-"babel-generator@6.25.0":
-  "integrity" "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw="
-  "resolved" "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz"
-  "version" "6.25.0"
+babel-generator@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz"
+  integrity sha1-rBriAHC3n248odMmlhMFN3TyDcU=
   dependencies:
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.25.0"
-    "detect-indent" "^4.0.0"
-    "jsesc" "^1.3.0"
-    "lodash" "^4.2.0"
-    "source-map" "^0.5.0"
-    "trim-right" "^1.0.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.6"
+    trim-right "^1.0.1"
 
-"babel-helper-builder-binary-assignment-operator-visitor@^6.24.1":
-  "integrity" "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ="
-  "resolved" "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz"
+  integrity sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=
   dependencies:
-    "babel-helper-explode-assignable-expression" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.24.1"
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
-"babel-helper-call-delegate@^6.24.1":
-  "integrity" "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
-  "resolved" "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-call-delegate@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz"
+  integrity sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=
   dependencies:
-    "babel-helper-hoist-variables" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-traverse" "^6.24.1"
-    "babel-types" "^6.24.1"
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
-"babel-helper-define-map@^6.24.1":
-  "integrity" "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8="
-  "resolved" "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz"
-  "version" "6.26.0"
+babel-helper-define-map@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz"
+  integrity sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=
   dependencies:
-    "babel-helper-function-name" "^6.24.1"
-    "babel-runtime" "^6.26.0"
-    "babel-types" "^6.26.0"
-    "lodash" "^4.17.4"
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
-"babel-helper-evaluate-path@^0.5.0":
-  "integrity" "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA=="
-  "resolved" "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz"
-  "version" "0.5.0"
+babel-helper-evaluate-path@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz"
+  integrity sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==
 
-"babel-helper-explode-assignable-expression@^6.24.1":
-  "integrity" "sha1-8luCz33BBDPFX3BZLVdGQArCLKo="
-  "resolved" "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz"
+  integrity sha1-8luCz33BBDPFX3BZLVdGQArCLKo=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-traverse" "^6.24.1"
-    "babel-types" "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
-"babel-helper-flip-expressions@^0.4.3":
-  "integrity" "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
-  "resolved" "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz"
-  "version" "0.4.3"
+babel-helper-flip-expressions@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz"
+  integrity sha1-NpZzahKKwYvCUlS19AoizrPB0/0=
 
-"babel-helper-function-name@^6.22.0":
-  "integrity" "sha1-JXQtZxdciQPb5LbLnZ4fy43PI6Y="
-  "resolved" "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz"
-  "version" "6.23.0"
+babel-helper-function-name@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz"
+  integrity sha1-JXQtZxdciQPb5LbLnZ4fy43PI6Y=
   dependencies:
-    "babel-helper-get-function-arity" "^6.22.0"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.23.0"
-    "babel-traverse" "^6.23.0"
-    "babel-types" "^6.23.0"
+    babel-helper-get-function-arity "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
-"babel-helper-function-name@^6.24.1":
-  "integrity" "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
-  "resolved" "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-function-name@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz"
+  integrity sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=
   dependencies:
-    "babel-helper-get-function-arity" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-    "babel-traverse" "^6.24.1"
-    "babel-types" "^6.24.1"
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
-"babel-helper-get-function-arity@^6.22.0":
-  "integrity" "sha1-C+tGStadxzR0EKxq3p8DpQY09c4="
-  "resolved" "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz"
-  "version" "6.22.0"
+babel-helper-get-function-arity@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz"
+  integrity sha1-C+tGStadxzR0EKxq3p8DpQY09c4=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
 
-"babel-helper-get-function-arity@^6.24.1":
-  "integrity" "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
-  "resolved" "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-get-function-arity@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+  integrity sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
-"babel-helper-hoist-variables@^6.24.1":
-  "integrity" "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
-  "resolved" "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-hoist-variables@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
+  integrity sha1-HssnaJydJVE+rbyZFKc/VAi+enY=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
-"babel-helper-is-nodes-equiv@^0.0.1":
-  "integrity" "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
-  "resolved" "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz"
-  "version" "0.0.1"
+babel-helper-is-nodes-equiv@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz"
+  integrity sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=
 
-"babel-helper-is-void-0@^0.4.3":
-  "integrity" "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4="
-  "resolved" "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz"
-  "version" "0.4.3"
+babel-helper-is-void-0@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz"
+  integrity sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4=
 
-"babel-helper-mark-eval-scopes@^0.4.3":
-  "integrity" "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
-  "resolved" "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz"
-  "version" "0.4.3"
+babel-helper-mark-eval-scopes@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz"
+  integrity sha1-0kSjvvmESHJgP/tG4izorN9VFWI=
 
-"babel-helper-optimise-call-expression@^6.23.0":
-  "integrity" "sha1-8+5+7TVbQoITizPQK3g2nkcGIvU="
-  "resolved" "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz"
-  "version" "6.23.0"
+babel-helper-optimise-call-expression@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz"
+  integrity sha1-8+5+7TVbQoITizPQK3g2nkcGIvU=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.23.0"
 
-"babel-helper-optimise-call-expression@^6.24.1":
-  "integrity" "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
-  "resolved" "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-optimise-call-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+  integrity sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
-"babel-helper-regex@^6.22.0":
-  "integrity" "sha1-efUyvhZHsfDuNHS19cPaWAAdJH0="
-  "resolved" "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz"
-  "version" "6.22.0"
+babel-helper-regex@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz"
+  integrity sha1-efUyvhZHsfDuNHS19cPaWAAdJH0=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.22.0"
-    "lodash" "^4.2.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+    lodash "^4.2.0"
 
-"babel-helper-remap-async-to-generator@^6.24.1":
-  "integrity" "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs="
-  "resolved" "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz"
+  integrity sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=
   dependencies:
-    "babel-helper-function-name" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-    "babel-traverse" "^6.24.1"
-    "babel-types" "^6.24.1"
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
-"babel-helper-remove-or-void@^0.4.3":
-  "integrity" "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
-  "resolved" "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz"
-  "version" "0.4.3"
+babel-helper-remove-or-void@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz"
+  integrity sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=
 
-"babel-helper-replace-supers@^6.22.0":
-  "integrity" "sha1-7q+K2bWOxDN8qUIjus3KH42bS/0="
-  "resolved" "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz"
-  "version" "6.23.0"
+babel-helper-replace-supers@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz"
+  integrity sha1-7q+K2bWOxDN8qUIjus3KH42bS/0=
   dependencies:
-    "babel-helper-optimise-call-expression" "^6.23.0"
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.23.0"
-    "babel-traverse" "^6.23.0"
-    "babel-types" "^6.23.0"
+    babel-helper-optimise-call-expression "^6.23.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
-"babel-helper-replace-supers@^6.24.1":
-  "integrity" "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
-  "resolved" "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helper-replace-supers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
+  integrity sha1-v22/5Dk40XNpohPKiov3S2qQqxo=
   dependencies:
-    "babel-helper-optimise-call-expression" "^6.24.1"
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-    "babel-traverse" "^6.24.1"
-    "babel-types" "^6.24.1"
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
-"babel-helper-to-multiple-sequence-expressions@^0.5.0":
-  "integrity" "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA=="
-  "resolved" "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz"
-  "version" "0.5.0"
+babel-helper-to-multiple-sequence-expressions@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz"
+  integrity sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==
 
-"babel-helpers@^6.24.1":
-  "integrity" "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
-  "resolved" "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
-  "version" "6.24.1"
+babel-helpers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
+  integrity sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
   dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
-"babel-messages@^6.23.0", "babel-messages@^6.8.0":
-  "integrity" "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
-  "resolved" "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-  "version" "6.23.0"
+babel-messages@^6.23.0, babel-messages@^6.8.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
   dependencies:
-    "babel-runtime" "^6.22.0"
+    babel-runtime "^6.22.0"
 
-"babel-minify@0.5.1":
-  "integrity" "sha512-ftEYu5OCDXEqaX/eINIaekPgkCaVPJNwFHzXKKARnRLggK8g4a9dEOflLKDgRNYOwhcLVoicUchZG6FYyOpqSA=="
-  "resolved" "https://registry.npmjs.org/babel-minify/-/babel-minify-0.5.1.tgz"
-  "version" "0.5.1"
+babel-minify@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/babel-minify/-/babel-minify-0.5.1.tgz"
+  integrity sha512-ftEYu5OCDXEqaX/eINIaekPgkCaVPJNwFHzXKKARnRLggK8g4a9dEOflLKDgRNYOwhcLVoicUchZG6FYyOpqSA==
   dependencies:
     "@babel/core" "^7.1.0"
-    "babel-preset-minify" "^0.5.1"
-    "fs-readdir-recursive" "^1.1.0"
-    "lodash" "^4.17.11"
-    "mkdirp" "^0.5.1"
-    "util.promisify" "^1.0.0"
-    "yargs-parser" "^10.0.0"
-
-"babel-plugin-check-es2015-constants@^6.22.0":
-  "integrity" "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
-  "resolved" "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-external-helpers@6.22.0":
-  "integrity" "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E="
-  "resolved" "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-minify-builtins@^0.5.0":
-  "integrity" "sha512-wpqbN7Ov5hsNwGdzuzvFcjgRlzbIeVv1gMIlICbPj0xkexnfoIDe7q+AZHMkQmAE/F9R5jkrB6TLfTegImlXag=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz"
-  "version" "0.5.0"
-
-"babel-plugin-minify-constant-folding@^0.5.0":
-  "integrity" "sha512-Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz"
-  "version" "0.5.0"
-  dependencies:
-    "babel-helper-evaluate-path" "^0.5.0"
-
-"babel-plugin-minify-dead-code-elimination@^0.5.1":
-  "integrity" "sha512-x8OJOZIrRmQBcSqxBcLbMIK8uPmTvNWPXH2bh5MDCW1latEqYiRMuUkPImKcfpo59pTUB2FT7HfcgtG8ZlR5Qg=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz"
-  "version" "0.5.1"
-  dependencies:
-    "babel-helper-evaluate-path" "^0.5.0"
-    "babel-helper-mark-eval-scopes" "^0.4.3"
-    "babel-helper-remove-or-void" "^0.4.3"
-    "lodash" "^4.17.11"
-
-"babel-plugin-minify-flip-comparisons@^0.4.3":
-  "integrity" "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz"
-  "version" "0.4.3"
-  dependencies:
-    "babel-helper-is-void-0" "^0.4.3"
-
-"babel-plugin-minify-guarded-expressions@^0.4.4":
-  "integrity" "sha512-RMv0tM72YuPPfLT9QLr3ix9nwUIq+sHT6z8Iu3sLbqldzC1Dls8DPCywzUIzkTx9Zh1hWX4q/m9BPoPed9GOfA=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz"
-  "version" "0.4.4"
-  dependencies:
-    "babel-helper-evaluate-path" "^0.5.0"
-    "babel-helper-flip-expressions" "^0.4.3"
-
-"babel-plugin-minify-infinity@^0.4.3":
-  "integrity" "sha1-37h2obCKBldjhO8/kuZTumB7Oco="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz"
-  "version" "0.4.3"
-
-"babel-plugin-minify-mangle-names@^0.5.0":
-  "integrity" "sha512-3jdNv6hCAw6fsX1p2wBGPfWuK69sfOjfd3zjUXkbq8McbohWy23tpXfy5RnToYWggvqzuMOwlId1PhyHOfgnGw=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz"
-  "version" "0.5.0"
-  dependencies:
-    "babel-helper-mark-eval-scopes" "^0.4.3"
-
-"babel-plugin-minify-numeric-literals@^0.4.3":
-  "integrity" "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz"
-  "version" "0.4.3"
-
-"babel-plugin-minify-replace@^0.5.0":
-  "integrity" "sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz"
-  "version" "0.5.0"
-
-"babel-plugin-minify-simplify@^0.5.1":
-  "integrity" "sha512-OSYDSnoCxP2cYDMk9gxNAed6uJDiDz65zgL6h8d3tm8qXIagWGMLWhqysT6DY3Vs7Fgq7YUDcjOomhVUb+xX6A=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz"
-  "version" "0.5.1"
-  dependencies:
-    "babel-helper-evaluate-path" "^0.5.0"
-    "babel-helper-flip-expressions" "^0.4.3"
-    "babel-helper-is-nodes-equiv" "^0.0.1"
-    "babel-helper-to-multiple-sequence-expressions" "^0.5.0"
-
-"babel-plugin-minify-type-constructors@^0.4.3":
-  "integrity" "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA="
-  "resolved" "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz"
-  "version" "0.4.3"
-  dependencies:
-    "babel-helper-is-void-0" "^0.4.3"
-
-"babel-plugin-syntax-async-functions@^6.8.0":
-  "integrity" "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-  "resolved" "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
-  "version" "6.13.0"
-
-"babel-plugin-syntax-exponentiation-operator@^6.8.0":
-  "integrity" "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-  "resolved" "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
-  "version" "6.13.0"
-
-"babel-plugin-syntax-trailing-function-commas@^6.22.0":
-  "integrity" "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-  "resolved" "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
-  "version" "6.22.0"
-
-"babel-plugin-transform-async-to-generator@^6.22.0":
-  "integrity" "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-helper-remap-async-to-generator" "^6.24.1"
-    "babel-plugin-syntax-async-functions" "^6.8.0"
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-arrow-functions@^6.22.0":
-  "integrity" "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-block-scoped-functions@^6.22.0":
-  "integrity" "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-block-scoping@^6.23.0":
-  "integrity" "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "babel-runtime" "^6.26.0"
-    "babel-template" "^6.26.0"
-    "babel-traverse" "^6.26.0"
-    "babel-types" "^6.26.0"
-    "lodash" "^4.17.4"
-
-"babel-plugin-transform-es2015-classes@^6.23.0":
-  "integrity" "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-helper-define-map" "^6.24.1"
-    "babel-helper-function-name" "^6.24.1"
-    "babel-helper-optimise-call-expression" "^6.24.1"
-    "babel-helper-replace-supers" "^6.24.1"
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-    "babel-traverse" "^6.24.1"
-    "babel-types" "^6.24.1"
-
-"babel-plugin-transform-es2015-computed-properties@^6.22.0":
-  "integrity" "sha1-fDg+lim7pIIMEbBCW91ikPfwV+c="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.22.0"
-
-"babel-plugin-transform-es2015-destructuring@^6.23.0":
-  "integrity" "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-duplicate-keys@^6.22.0":
-  "integrity" "sha1-ZyOXAxwhYQ1y3Su7C6n7Ynfhw2s="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.22.0"
-
-"babel-plugin-transform-es2015-for-of@^6.23.0":
-  "integrity" "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-function-name@^6.22.0":
-  "integrity" "sha1-9fzIsJCT+aI8dqw9njksPsS3cQQ="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-helper-function-name" "^6.22.0"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.22.0"
-
-"babel-plugin-transform-es2015-literals@^6.22.0":
-  "integrity" "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-modules-amd@^6.22.0", "babel-plugin-transform-es2015-modules-amd@^6.24.1":
-  "integrity" "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-plugin-transform-es2015-modules-commonjs" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-
-"babel-plugin-transform-es2015-modules-commonjs@^6.23.0", "babel-plugin-transform-es2015-modules-commonjs@^6.24.1":
-  "integrity" "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "babel-plugin-transform-strict-mode" "^6.24.1"
-    "babel-runtime" "^6.26.0"
-    "babel-template" "^6.26.0"
-    "babel-types" "^6.26.0"
-
-"babel-plugin-transform-es2015-modules-systemjs@^6.23.0":
-  "integrity" "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-helper-hoist-variables" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-
-"babel-plugin-transform-es2015-modules-umd@^6.23.0":
-  "integrity" "sha1-rJl+YoXNGO1hdq22B9YCNErThGg="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-plugin-transform-es2015-modules-amd" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-
-"babel-plugin-transform-es2015-object-super@^6.22.0":
-  "integrity" "sha1-2qYOEUoELqdp3VP+Uo/IIxHrmPw="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-helper-replace-supers" "^6.22.0"
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-parameters@^6.23.0":
-  "integrity" "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-helper-call-delegate" "^6.24.1"
-    "babel-helper-get-function-arity" "^6.24.1"
-    "babel-runtime" "^6.22.0"
-    "babel-template" "^6.24.1"
-    "babel-traverse" "^6.24.1"
-    "babel-types" "^6.24.1"
-
-"babel-plugin-transform-es2015-shorthand-properties@^6.22.0":
-  "integrity" "sha1-i6d24K/6pgv/IekhQDuKZSov9yM="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.22.0"
-
-"babel-plugin-transform-es2015-spread@^6.22.0":
-  "integrity" "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-sticky-regex@^6.22.0":
-  "integrity" "sha1-qzFoKehm7j9LnrlpOXV9GaW8RZM="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-helper-regex" "^6.22.0"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.22.0"
-
-"babel-plugin-transform-es2015-template-literals@^6.22.0":
-  "integrity" "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-typeof-symbol@^6.23.0":
-  "integrity" "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-es2015-unicode-regex@^6.22.0":
-  "integrity" "sha1-jZzCfn7h3s/mVFT7mGRSoEphPSA="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "babel-helper-regex" "^6.22.0"
-    "babel-runtime" "^6.22.0"
-    "regexpu-core" "^2.0.0"
-
-"babel-plugin-transform-exponentiation-operator@^6.22.0":
-  "integrity" "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-helper-builder-binary-assignment-operator-visitor" "^6.24.1"
-    "babel-plugin-syntax-exponentiation-operator" "^6.8.0"
-    "babel-runtime" "^6.22.0"
-
-"babel-plugin-transform-inline-consecutive-adds@^0.4.3":
-  "integrity" "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz"
-  "version" "0.4.3"
-
-"babel-plugin-transform-member-expression-literals@^6.9.4":
-  "integrity" "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz"
-  "version" "6.9.4"
-
-"babel-plugin-transform-merge-sibling-variables@^6.9.4":
-  "integrity" "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz"
-  "version" "6.9.4"
-
-"babel-plugin-transform-minify-booleans@^6.9.4":
-  "integrity" "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz"
-  "version" "6.9.4"
-
-"babel-plugin-transform-property-literals@^6.9.4":
-  "integrity" "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz"
-  "version" "6.9.4"
-  dependencies:
-    "esutils" "^2.0.2"
-
-"babel-plugin-transform-regenerator@^6.22.0":
-  "integrity" "sha1-ZXQFk6MZxEUiFXU41pC4QJRhfqY="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz"
-  "version" "6.22.0"
-  dependencies:
-    "regenerator-transform" "0.9.8"
-
-"babel-plugin-transform-regexp-constructors@^0.4.3":
-  "integrity" "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz"
-  "version" "0.4.3"
-
-"babel-plugin-transform-remove-console@^6.9.4":
-  "integrity" "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz"
-  "version" "6.9.4"
-
-"babel-plugin-transform-remove-debugger@^6.9.4":
-  "integrity" "sha1-QrcnYxyXl44estGZp67IShgznvI="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz"
-  "version" "6.9.4"
-
-"babel-plugin-transform-remove-undefined@^0.5.0":
-  "integrity" "sha512-+M7fJYFaEE/M9CXa0/IRkDbiV3wRELzA1kKQFCJ4ifhrzLKn/9VCCgj9OFmYWwBd8IB48YdgPkHYtbYq+4vtHQ=="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz"
-  "version" "0.5.0"
-  dependencies:
-    "babel-helper-evaluate-path" "^0.5.0"
-
-"babel-plugin-transform-simplify-comparison-operators@^6.9.4":
-  "integrity" "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz"
-  "version" "6.9.4"
-
-"babel-plugin-transform-strict-mode@^6.24.1":
-  "integrity" "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.24.1"
-
-"babel-plugin-transform-undefined-to-void@^6.9.4":
-  "integrity" "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
-  "resolved" "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz"
-  "version" "6.9.4"
-
-"babel-preset-env@1.6.0":
-  "integrity" "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew=="
-  "resolved" "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz"
-  "version" "1.6.0"
-  dependencies:
-    "babel-plugin-check-es2015-constants" "^6.22.0"
-    "babel-plugin-syntax-trailing-function-commas" "^6.22.0"
-    "babel-plugin-transform-async-to-generator" "^6.22.0"
-    "babel-plugin-transform-es2015-arrow-functions" "^6.22.0"
-    "babel-plugin-transform-es2015-block-scoped-functions" "^6.22.0"
-    "babel-plugin-transform-es2015-block-scoping" "^6.23.0"
-    "babel-plugin-transform-es2015-classes" "^6.23.0"
-    "babel-plugin-transform-es2015-computed-properties" "^6.22.0"
-    "babel-plugin-transform-es2015-destructuring" "^6.23.0"
-    "babel-plugin-transform-es2015-duplicate-keys" "^6.22.0"
-    "babel-plugin-transform-es2015-for-of" "^6.23.0"
-    "babel-plugin-transform-es2015-function-name" "^6.22.0"
-    "babel-plugin-transform-es2015-literals" "^6.22.0"
-    "babel-plugin-transform-es2015-modules-amd" "^6.22.0"
-    "babel-plugin-transform-es2015-modules-commonjs" "^6.23.0"
-    "babel-plugin-transform-es2015-modules-systemjs" "^6.23.0"
-    "babel-plugin-transform-es2015-modules-umd" "^6.23.0"
-    "babel-plugin-transform-es2015-object-super" "^6.22.0"
-    "babel-plugin-transform-es2015-parameters" "^6.23.0"
-    "babel-plugin-transform-es2015-shorthand-properties" "^6.22.0"
-    "babel-plugin-transform-es2015-spread" "^6.22.0"
-    "babel-plugin-transform-es2015-sticky-regex" "^6.22.0"
-    "babel-plugin-transform-es2015-template-literals" "^6.22.0"
-    "babel-plugin-transform-es2015-typeof-symbol" "^6.23.0"
-    "babel-plugin-transform-es2015-unicode-regex" "^6.22.0"
-    "babel-plugin-transform-exponentiation-operator" "^6.22.0"
-    "babel-plugin-transform-regenerator" "^6.22.0"
-    "browserslist" "^2.1.2"
-    "invariant" "^2.2.2"
-    "semver" "^5.3.0"
-
-"babel-preset-minify@^0.5.1":
-  "integrity" "sha512-1IajDumYOAPYImkHbrKeiN5AKKP9iOmRoO2IPbIuVp0j2iuCcj0n7P260z38siKMZZ+85d3mJZdtW8IgOv+Tzg=="
-  "resolved" "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz"
-  "version" "0.5.1"
-  dependencies:
-    "babel-plugin-minify-builtins" "^0.5.0"
-    "babel-plugin-minify-constant-folding" "^0.5.0"
-    "babel-plugin-minify-dead-code-elimination" "^0.5.1"
-    "babel-plugin-minify-flip-comparisons" "^0.4.3"
-    "babel-plugin-minify-guarded-expressions" "^0.4.4"
-    "babel-plugin-minify-infinity" "^0.4.3"
-    "babel-plugin-minify-mangle-names" "^0.5.0"
-    "babel-plugin-minify-numeric-literals" "^0.4.3"
-    "babel-plugin-minify-replace" "^0.5.0"
-    "babel-plugin-minify-simplify" "^0.5.1"
-    "babel-plugin-minify-type-constructors" "^0.4.3"
-    "babel-plugin-transform-inline-consecutive-adds" "^0.4.3"
-    "babel-plugin-transform-member-expression-literals" "^6.9.4"
-    "babel-plugin-transform-merge-sibling-variables" "^6.9.4"
-    "babel-plugin-transform-minify-booleans" "^6.9.4"
-    "babel-plugin-transform-property-literals" "^6.9.4"
-    "babel-plugin-transform-regexp-constructors" "^0.4.3"
-    "babel-plugin-transform-remove-console" "^6.9.4"
-    "babel-plugin-transform-remove-debugger" "^6.9.4"
-    "babel-plugin-transform-remove-undefined" "^0.5.0"
-    "babel-plugin-transform-simplify-comparison-operators" "^6.9.4"
-    "babel-plugin-transform-undefined-to-void" "^6.9.4"
-    "lodash" "^4.17.11"
-
-"babel-register@^6.26.0":
-  "integrity" "sha1-btAhFz4vy0htestFxgCahW9kcHE="
-  "resolved" "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "babel-core" "^6.26.0"
-    "babel-runtime" "^6.26.0"
-    "core-js" "^2.5.0"
-    "home-or-tmp" "^2.0.0"
-    "lodash" "^4.17.4"
-    "mkdirp" "^0.5.1"
-    "source-map-support" "^0.4.15"
-
-"babel-runtime@^6.18.0", "babel-runtime@^6.22.0", "babel-runtime@^6.9.0", "babel-runtime@^6.9.1":
-  "integrity" "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
-  "resolved" "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "core-js" "^2.4.0"
-    "regenerator-runtime" "^0.10.0"
-
-"babel-runtime@^6.26.0":
-  "integrity" "sha1-llxwWGaOgrVde/4E/yM3vItWR/4="
-  "resolved" "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "core-js" "^2.4.0"
-    "regenerator-runtime" "^0.11.0"
-
-"babel-template@^6.22.0":
-  "integrity" "sha1-BNTycK27OqcEqBQ64m+qUpI45jg="
-  "resolved" "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-traverse" "^6.23.0"
-    "babel-types" "^6.23.0"
-    "babylon" "^6.11.0"
-    "lodash" "^4.2.0"
-
-"babel-template@^6.23.0":
-  "integrity" "sha1-BNTycK27OqcEqBQ64m+qUpI45jg="
-  "resolved" "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "babel-traverse" "^6.23.0"
-    "babel-types" "^6.23.0"
-    "babylon" "^6.11.0"
-    "lodash" "^4.2.0"
-
-"babel-template@^6.24.1", "babel-template@^6.26.0":
-  "integrity" "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI="
-  "resolved" "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "babel-runtime" "^6.26.0"
-    "babel-traverse" "^6.26.0"
-    "babel-types" "^6.26.0"
-    "babylon" "^6.18.0"
-    "lodash" "^4.17.4"
-
-"babel-template@6.16.0":
-  "integrity" "sha1-4UndGp8Do1+BfdvE0EgZiOfryMo="
-  "resolved" "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
-  "version" "6.16.0"
-  dependencies:
-    "babel-runtime" "^6.9.0"
-    "babel-traverse" "^6.16.0"
-    "babel-types" "^6.16.0"
-    "babylon" "^6.11.0"
-    "lodash" "^4.2.0"
-
-"babel-traverse@^6.0.20":
-  "integrity" "sha1-08tZAQ7NBql9gTEAZflmtpnhT0g="
-  "resolved" "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz"
-  "version" "6.23.1"
-  dependencies:
-    "babel-code-frame" "^6.22.0"
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.23.0"
-    "babylon" "^6.15.0"
-    "debug" "^2.2.0"
-    "globals" "^9.0.0"
-    "invariant" "^2.2.0"
-    "lodash" "^4.2.0"
-
-"babel-traverse@^6.16.0":
-  "integrity" "sha1-08tZAQ7NBql9gTEAZflmtpnhT0g="
-  "resolved" "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz"
-  "version" "6.23.1"
-  dependencies:
-    "babel-code-frame" "^6.22.0"
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.23.0"
-    "babylon" "^6.15.0"
-    "debug" "^2.2.0"
-    "globals" "^9.0.0"
-    "invariant" "^2.2.0"
-    "lodash" "^4.2.0"
-
-"babel-traverse@^6.23.0":
-  "integrity" "sha1-08tZAQ7NBql9gTEAZflmtpnhT0g="
-  "resolved" "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz"
-  "version" "6.23.1"
-  dependencies:
-    "babel-code-frame" "^6.22.0"
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.22.0"
-    "babel-types" "^6.23.0"
-    "babylon" "^6.15.0"
-    "debug" "^2.2.0"
-    "globals" "^9.0.0"
-    "invariant" "^2.2.0"
-    "lodash" "^4.2.0"
-
-"babel-traverse@^6.24.1", "babel-traverse@^6.26.0":
-  "integrity" "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4="
-  "resolved" "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "babel-code-frame" "^6.26.0"
-    "babel-messages" "^6.23.0"
-    "babel-runtime" "^6.26.0"
-    "babel-types" "^6.26.0"
-    "babylon" "^6.18.0"
-    "debug" "^2.6.8"
-    "globals" "^9.18.0"
-    "invariant" "^2.2.2"
-    "lodash" "^4.17.4"
-
-"babel-types@^6.0.19", "babel-types@^6.23.0":
-  "integrity" "sha1-uxcXnXU4utOM0MnhFdNA935+ms8="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.2.0"
-    "to-fast-properties" "^1.0.1"
-
-"babel-types@^6.16.0":
-  "integrity" "sha1-uxcXnXU4utOM0MnhFdNA935+ms8="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.2.0"
-    "to-fast-properties" "^1.0.1"
-
-"babel-types@^6.19.0":
-  "integrity" "sha1-uxcXnXU4utOM0MnhFdNA935+ms8="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.2.0"
-    "to-fast-properties" "^1.0.1"
-
-"babel-types@^6.22.0", "babel-types@^6.23.0":
-  "integrity" "sha1-uxcXnXU4utOM0MnhFdNA935+ms8="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
-  "version" "6.23.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.2.0"
-    "to-fast-properties" "^1.0.1"
-
-"babel-types@^6.24.1", "babel-types@^6.26.0":
-  "integrity" "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "babel-runtime" "^6.26.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.17.4"
-    "to-fast-properties" "^1.0.3"
-
-"babel-types@^6.25.0":
-  "integrity" "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-  "version" "6.26.0"
-  dependencies:
-    "babel-runtime" "^6.26.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.17.4"
-    "to-fast-properties" "^1.0.3"
-
-"babel-types@6.16.0":
-  "integrity" "sha1-ccyh2+Uzd2YiXFwZMHHo68vP/P4="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz"
-  "version" "6.16.0"
-  dependencies:
-    "babel-runtime" "^6.9.1"
-    "esutils" "^2.0.2"
-    "lodash" "^4.2.0"
-    "to-fast-properties" "^1.0.1"
-
-"babel-types@6.24.1":
-  "integrity" "sha1-oTaHncFbNga9oNkMH8dDBML/CXU="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-  "version" "6.24.1"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.2.0"
-    "to-fast-properties" "^1.0.1"
-
-"babel-types@6.25.0":
-  "integrity" "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
-  "resolved" "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
-  "version" "6.25.0"
-  dependencies:
-    "babel-runtime" "^6.22.0"
-    "esutils" "^2.0.2"
-    "lodash" "^4.2.0"
-    "to-fast-properties" "^1.0.1"
-
-"babel@6.23.0":
-  "integrity" "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ="
-  "resolved" "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz"
-  "version" "6.23.0"
-
-"babylon@^6.0.18", "babylon@^6.15.0":
-  "integrity" "sha1-MMWiL0gZeKnn+M399JaxHZS0BNM="
-  "resolved" "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz"
-  "version" "6.16.1"
-
-"babylon@^6.11.0", "babylon@6.11.2":
-  "integrity" "sha1-OmQ2H+3ubZ+CdqmrwMiKnlI3/3o="
-  "resolved" "https://registry.npmjs.org/babylon/-/babylon-6.11.2.tgz"
-  "version" "6.11.2"
-
-"babylon@^6.18.0":
-  "integrity" "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-  "resolved" "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz"
-  "version" "6.18.0"
-
-"balanced-match@^1.0.0":
-  "integrity" "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-  "resolved" "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-  "version" "1.0.0"
-
-"base@^0.11.1":
-  "integrity" "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg=="
-  "resolved" "https://registry.npmjs.org/base/-/base-0.11.2.tgz"
-  "version" "0.11.2"
-  dependencies:
-    "cache-base" "^1.0.1"
-    "class-utils" "^0.3.5"
-    "component-emitter" "^1.2.1"
-    "define-property" "^1.0.0"
-    "isobject" "^3.0.1"
-    "mixin-deep" "^1.2.0"
-    "pascalcase" "^0.1.1"
-
-"base64-js@^1.0.2":
-  "integrity" "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
-  "resolved" "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
-  "version" "1.2.1"
-
-"base64-js@0.0.8":
-  "integrity" "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
-  "resolved" "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
-  "version" "0.0.8"
-
-"bcrypt-pbkdf@^1.0.0":
-  "integrity" "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4="
-  "resolved" "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "tweetnacl" "^0.14.3"
-
-"beeper@^1.0.0":
-  "integrity" "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-  "resolved" "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz"
-  "version" "1.1.1"
-
-"bin-build@^2.2.0":
-  "integrity" "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw="
-  "resolved" "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz"
-  "version" "2.2.0"
-  dependencies:
-    "archive-type" "^3.0.1"
-    "decompress" "^3.0.0"
-    "download" "^4.1.2"
-    "exec-series" "^1.0.0"
-    "rimraf" "^2.2.6"
-    "tempfile" "^1.0.0"
-    "url-regex" "^3.0.0"
-
-"binary-extensions@^1.0.0":
-  "integrity" "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
-  "resolved" "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz"
-  "version" "1.12.0"
-
-"bl@^1.0.0":
-  "integrity" "sha1-E5fn7ELF9dw4dHDFAONKn2vp6pg="
-  "resolved" "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz"
-  "version" "1.2.0"
-  dependencies:
-    "readable-stream" "^2.0.5"
-
-"bl@~0.8.1":
-  "integrity" "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4="
-  "resolved" "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz"
-  "version" "0.8.2"
-  dependencies:
-    "readable-stream" "~1.0.26"
-
-"bl@~0.9.0":
-  "integrity" "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ="
-  "resolved" "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
-  "version" "0.9.5"
-  dependencies:
-    "readable-stream" "~1.0.26"
-
-"bluebird@^3.5.4":
-  "integrity" "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
-  "resolved" "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz"
-  "version" "3.5.5"
-
-"bn.js@^4.0.0", "bn.js@^4.1.0", "bn.js@^4.1.1", "bn.js@^4.4.0":
-  "integrity" "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-  "resolved" "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
-  "version" "4.11.6"
-
-"body@^5.1.0":
-  "integrity" "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk="
-  "resolved" "https://registry.npmjs.org/body/-/body-5.1.0.tgz"
-  "version" "5.1.0"
-  dependencies:
-    "continuable-cache" "^0.3.1"
-    "error" "^7.0.0"
-    "raw-body" "~1.1.0"
-    "safe-json-parse" "~1.0.1"
-
-"boom@0.4.x":
-  "integrity" "sha1-emNune1O/O+xnO9JR6PGffrukRs="
-  "resolved" "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-  "version" "0.4.2"
-  dependencies:
-    "hoek" "0.9.x"
-
-"boom@2.x.x":
-  "integrity" "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
-  "resolved" "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-  "version" "2.10.1"
-  dependencies:
-    "hoek" "2.x.x"
-
-"brace-expansion@^1.0.0":
-  "integrity" "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="
-  "resolved" "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
-  "version" "1.1.11"
-  dependencies:
-    "balanced-match" "^1.0.0"
-    "concat-map" "0.0.1"
-
-"brace-expansion@^1.1.7":
-  "integrity" "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
-  "resolved" "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
-  "version" "1.1.8"
-  dependencies:
-    "balanced-match" "^1.0.0"
-    "concat-map" "0.0.1"
-
-"braces@^1.8.2":
-  "integrity" "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
-  "resolved" "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-  "version" "1.8.5"
-  dependencies:
-    "expand-range" "^1.8.1"
-    "preserve" "^0.2.0"
-    "repeat-element" "^1.1.2"
-
-"braces@^2.3.1":
-  "integrity" "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w=="
-  "resolved" "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz"
-  "version" "2.3.2"
-  dependencies:
-    "arr-flatten" "^1.1.0"
-    "array-unique" "^0.3.2"
-    "extend-shallow" "^2.0.1"
-    "fill-range" "^4.0.0"
-    "isobject" "^3.0.1"
-    "repeat-element" "^1.1.2"
-    "snapdragon" "^0.8.1"
-    "snapdragon-node" "^2.0.1"
-    "split-string" "^3.0.2"
-    "to-regex" "^3.0.1"
-
-"brorand@^1.0.1":
-  "integrity" "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-  "resolved" "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
-  "version" "1.1.0"
-
-"browser-resolve@^1.11.0":
-  "integrity" "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4="
-  "resolved" "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
-  "version" "1.11.2"
-  dependencies:
-    "resolve" "1.1.7"
-
-"browser-stdout@1.3.0":
-  "integrity" "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
-  "resolved" "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
-  "version" "1.3.0"
-
-"browserify-aes@^1.0.0", "browserify-aes@^1.0.4":
-  "integrity" "sha1-Xncl297x/Vkw1OurSFZ85FHEigo="
-  "resolved" "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
-  "version" "1.0.6"
-  dependencies:
-    "buffer-xor" "^1.0.2"
-    "cipher-base" "^1.0.0"
-    "create-hash" "^1.1.0"
-    "evp_bytestokey" "^1.0.0"
-    "inherits" "^2.0.1"
-
-"browserify-cipher@^1.0.0":
-  "integrity" "sha1-mYgkSHS/XtTijalWZtzWasj8Njo="
-  "resolved" "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "browserify-aes" "^1.0.4"
-    "browserify-des" "^1.0.0"
-    "evp_bytestokey" "^1.0.0"
-
-"browserify-des@^1.0.0":
-  "integrity" "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0="
-  "resolved" "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "cipher-base" "^1.0.1"
-    "des.js" "^1.0.0"
-    "inherits" "^2.0.1"
-
-"browserify-fs@^1.0.0":
-  "integrity" "sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8="
-  "resolved" "https://registry.npmjs.org/browserify-fs/-/browserify-fs-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "level-filesystem" "^1.0.1"
-    "level-js" "^2.1.3"
-    "levelup" "^0.18.2"
-
-"browserify-rsa@^4.0.0":
-  "integrity" "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ="
-  "resolved" "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
-  "version" "4.0.1"
-  dependencies:
-    "bn.js" "^4.1.0"
-    "randombytes" "^2.0.1"
-
-"browserify-sign@^4.0.0":
-  "integrity" "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg="
-  "resolved" "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz"
-  "version" "4.0.4"
-  dependencies:
-    "bn.js" "^4.1.1"
-    "browserify-rsa" "^4.0.0"
-    "create-hash" "^1.1.0"
-    "create-hmac" "^1.1.2"
-    "elliptic" "^6.0.0"
-    "inherits" "^2.0.1"
-    "parse-asn1" "^5.0.0"
-
-"browserslist@^2.1.2":
-  "integrity" "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ=="
-  "resolved" "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz"
-  "version" "2.4.0"
-  dependencies:
-    "caniuse-lite" "^1.0.30000718"
-    "electron-to-chromium" "^1.3.18"
-
-"browserslist@^4.16.6":
-  "integrity" "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ=="
-  "resolved" "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz"
-  "version" "4.16.8"
-  dependencies:
-    "caniuse-lite" "^1.0.30001251"
-    "colorette" "^1.3.0"
-    "electron-to-chromium" "^1.3.811"
-    "escalade" "^3.1.1"
-    "node-releases" "^1.1.75"
-
-"buf-compare@^1.0.0":
-  "integrity" "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
-  "resolved" "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz"
-  "version" "1.0.1"
-
-"buffer-crc32@~0.2.3":
-  "integrity" "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-  "resolved" "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
-  "version" "0.2.13"
-
-"buffer-es6@^4.9.1", "buffer-es6@^4.9.2":
-  "integrity" "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ="
-  "resolved" "https://registry.npmjs.org/buffer-es6/-/buffer-es6-4.9.3.tgz"
-  "version" "4.9.3"
-
-"buffer-shims@^1.0.0":
-  "integrity" "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-  "resolved" "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-  "version" "1.0.0"
-
-"buffer-to-vinyl@^1.0.0":
-  "integrity" "sha1-APFfruOreh3aLN5tkSG//dB7ImI="
-  "resolved" "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz"
-  "version" "1.1.0"
-  dependencies:
-    "file-type" "^3.1.0"
-    "readable-stream" "^2.0.2"
-    "uuid" "^2.0.1"
-    "vinyl" "^1.0.0"
-
-"buffer-xor@^1.0.2":
-  "integrity" "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-  "resolved" "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
-  "version" "1.0.3"
-
-"buffer@^3.0.1":
-  "integrity" "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs="
-  "resolved" "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
-  "version" "3.6.0"
-  dependencies:
-    "base64-js" "0.0.8"
-    "ieee754" "^1.1.4"
-    "isarray" "^1.0.0"
-
-"buffer@4.9.1":
-  "integrity" "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg="
-  "resolved" "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
-  "version" "4.9.1"
-  dependencies:
-    "base64-js" "^1.0.2"
-    "ieee754" "^1.1.4"
-    "isarray" "^1.0.0"
-
-"builtin-modules@^1.1.0", "builtin-modules@^1.1.1":
-  "integrity" "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-  "resolved" "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-  "version" "1.1.1"
-
-"bytes@1":
-  "integrity" "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
-  "resolved" "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
-  "version" "1.0.0"
-
-"cache-base@^1.0.1":
-  "integrity" "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ=="
-  "resolved" "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz"
-  "version" "1.0.1"
-  dependencies:
-    "collection-visit" "^1.0.0"
-    "component-emitter" "^1.2.1"
-    "get-value" "^2.0.6"
-    "has-value" "^1.0.0"
-    "isobject" "^3.0.1"
-    "set-value" "^2.0.0"
-    "to-object-path" "^0.3.0"
-    "union-value" "^1.0.0"
-    "unset-value" "^1.0.0"
-
-"cache-point@^0.4.1":
-  "integrity" "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q=="
-  "resolved" "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz"
-  "version" "0.4.1"
-  dependencies:
-    "array-back" "^2.0.0"
-    "fs-then-native" "^2.0.0"
-    "mkdirp2" "^1.0.3"
-
-"caller-path@^0.1.0":
-  "integrity" "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8="
-  "resolved" "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
-  "version" "0.1.0"
-  dependencies:
-    "callsites" "^0.2.0"
-
-"callsites@^0.2.0":
-  "integrity" "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
-  "resolved" "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-  "version" "0.2.0"
-
-"camelcase@^4.1.0":
-  "integrity" "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-  "resolved" "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
-  "version" "4.1.0"
-
-"caniuse-lite@^1.0.30000718":
-  "integrity" "sha1-6/xIJUEXzAxmGXpFNstDl6bPvM0="
-  "resolved" "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000733.tgz"
-  "version" "1.0.30000733"
-
-"caniuse-lite@^1.0.30001251":
-  "integrity" "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw=="
-  "resolved" "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz"
-  "version" "1.0.30001252"
-
-"capture-stack-trace@^1.0.0":
-  "integrity" "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
-  "resolved" "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
-  "version" "1.0.0"
-
-"caseless@~0.12.0":
-  "integrity" "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-  "resolved" "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-  "version" "0.12.0"
-
-"caseless@~0.8.0":
-  "integrity" "sha1-W8oogdQUN/VLJAfr40iIx7mtT30="
-  "resolved" "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-  "version" "0.8.0"
-
-"catharsis@^0.8.11":
-  "integrity" "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g=="
-  "resolved" "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz"
-  "version" "0.8.11"
-  dependencies:
-    "lodash" "^4.17.14"
-
-"caw@^1.0.1":
-  "integrity" "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ="
-  "resolved" "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz"
-  "version" "1.2.0"
-  dependencies:
-    "get-proxy" "^1.0.1"
-    "is-obj" "^1.0.0"
-    "object-assign" "^3.0.0"
-    "tunnel-agent" "^0.4.0"
-
-"caw@^2.0.0":
-  "integrity" "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA=="
-  "resolved" "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "get-proxy" "^2.0.0"
-    "isurl" "^1.0.0-alpha5"
-    "tunnel-agent" "^0.6.0"
-    "url-to-options" "^1.0.1"
-
-"chalk@^1.0.0", "chalk@^1.1.0", "chalk@^1.1.1", "chalk@^1.1.3":
-  "integrity" "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
-  "resolved" "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-  "version" "1.1.3"
-  dependencies:
-    "ansi-styles" "^2.2.1"
-    "escape-string-regexp" "^1.0.2"
-    "has-ansi" "^2.0.0"
-    "strip-ansi" "^3.0.0"
-    "supports-color" "^2.0.0"
-
-"chalk@^2.0.0":
-  "integrity" "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="
-  "resolved" "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
-  "version" "2.4.2"
-  dependencies:
-    "ansi-styles" "^3.2.1"
-    "escape-string-regexp" "^1.0.5"
-    "supports-color" "^5.3.0"
-
-"chalk@0.5.1":
-  "integrity" "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ="
-  "resolved" "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
-  "version" "0.5.1"
-  dependencies:
-    "ansi-styles" "^1.1.0"
-    "escape-string-regexp" "^1.0.0"
-    "has-ansi" "^0.1.0"
-    "strip-ansi" "^0.3.0"
-    "supports-color" "^0.2.0"
-
-"chokidar@^1.7.0":
-  "integrity" "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg="
-  "resolved" "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz"
-  "version" "1.7.0"
-  dependencies:
-    "anymatch" "^1.3.0"
-    "async-each" "^1.0.0"
-    "glob-parent" "^2.0.0"
-    "inherits" "^2.0.1"
-    "is-binary-path" "^1.0.0"
-    "is-glob" "^2.0.0"
-    "path-is-absolute" "^1.0.0"
-    "readdirp" "^2.0.0"
+    babel-preset-minify "^0.5.1"
+    fs-readdir-recursive "^1.1.0"
+    lodash "^4.17.11"
+    mkdirp "^0.5.1"
+    util.promisify "^1.0.0"
+    yargs-parser "^10.0.0"
+
+babel-plugin-check-es2015-constants@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz"
+  integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-external-helpers@6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz"
+  integrity sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-minify-builtins@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz"
+  integrity sha512-wpqbN7Ov5hsNwGdzuzvFcjgRlzbIeVv1gMIlICbPj0xkexnfoIDe7q+AZHMkQmAE/F9R5jkrB6TLfTegImlXag==
+
+babel-plugin-minify-constant-folding@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz"
+  integrity sha512-Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ==
+  dependencies:
+    babel-helper-evaluate-path "^0.5.0"
+
+babel-plugin-minify-dead-code-elimination@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz"
+  integrity sha512-x8OJOZIrRmQBcSqxBcLbMIK8uPmTvNWPXH2bh5MDCW1latEqYiRMuUkPImKcfpo59pTUB2FT7HfcgtG8ZlR5Qg==
+  dependencies:
+    babel-helper-evaluate-path "^0.5.0"
+    babel-helper-mark-eval-scopes "^0.4.3"
+    babel-helper-remove-or-void "^0.4.3"
+    lodash "^4.17.11"
+
+babel-plugin-minify-flip-comparisons@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz"
+  integrity sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=
+  dependencies:
+    babel-helper-is-void-0 "^0.4.3"
+
+babel-plugin-minify-guarded-expressions@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz"
+  integrity sha512-RMv0tM72YuPPfLT9QLr3ix9nwUIq+sHT6z8Iu3sLbqldzC1Dls8DPCywzUIzkTx9Zh1hWX4q/m9BPoPed9GOfA==
+  dependencies:
+    babel-helper-evaluate-path "^0.5.0"
+    babel-helper-flip-expressions "^0.4.3"
+
+babel-plugin-minify-infinity@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz"
+  integrity sha1-37h2obCKBldjhO8/kuZTumB7Oco=
+
+babel-plugin-minify-mangle-names@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz"
+  integrity sha512-3jdNv6hCAw6fsX1p2wBGPfWuK69sfOjfd3zjUXkbq8McbohWy23tpXfy5RnToYWggvqzuMOwlId1PhyHOfgnGw==
+  dependencies:
+    babel-helper-mark-eval-scopes "^0.4.3"
+
+babel-plugin-minify-numeric-literals@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz"
+  integrity sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw=
+
+babel-plugin-minify-replace@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz"
+  integrity sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q==
+
+babel-plugin-minify-simplify@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz"
+  integrity sha512-OSYDSnoCxP2cYDMk9gxNAed6uJDiDz65zgL6h8d3tm8qXIagWGMLWhqysT6DY3Vs7Fgq7YUDcjOomhVUb+xX6A==
+  dependencies:
+    babel-helper-evaluate-path "^0.5.0"
+    babel-helper-flip-expressions "^0.4.3"
+    babel-helper-is-nodes-equiv "^0.0.1"
+    babel-helper-to-multiple-sequence-expressions "^0.5.0"
+
+babel-plugin-minify-type-constructors@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz"
+  integrity sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=
+  dependencies:
+    babel-helper-is-void-0 "^0.4.3"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
+  integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+  integrity sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
+  integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
+
+babel-plugin-transform-async-to-generator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz"
+  integrity sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-arrow-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz"
+  integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz"
+  integrity sha1-u8UbSflk1wy42OC5ToICRs46YUE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz"
+  integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-plugin-transform-es2015-classes@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz"
+  integrity sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=
+  dependencies:
+    babel-helper-define-map "^6.24.1"
+    babel-helper-function-name "^6.24.1"
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-helper-replace-supers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz"
+  integrity sha1-fDg+lim7pIIMEbBCW91ikPfwV+c=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.22.0"
+
+babel-plugin-transform-es2015-destructuring@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz"
+  integrity sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz"
+  integrity sha1-ZyOXAxwhYQ1y3Su7C6n7Ynfhw2s=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+
+babel-plugin-transform-es2015-for-of@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz"
+  integrity sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-function-name@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz"
+  integrity sha1-9fzIsJCT+aI8dqw9njksPsS3cQQ=
+  dependencies:
+    babel-helper-function-name "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+
+babel-plugin-transform-es2015-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz"
+  integrity sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz"
+  integrity sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=
+  dependencies:
+    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz"
+  integrity sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz"
+  integrity sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz"
+  integrity sha1-rJl+YoXNGO1hdq22B9YCNErThGg=
+  dependencies:
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-object-super@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz"
+  integrity sha1-2qYOEUoELqdp3VP+Uo/IIxHrmPw=
+  dependencies:
+    babel-helper-replace-supers "^6.22.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-parameters@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz"
+  integrity sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=
+  dependencies:
+    babel-helper-call-delegate "^6.24.1"
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz"
+  integrity sha1-i6d24K/6pgv/IekhQDuKZSov9yM=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+
+babel-plugin-transform-es2015-spread@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz"
+  integrity sha1-1taKmfia7cRTbIGlQujdnxdG+NE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz"
+  integrity sha1-qzFoKehm7j9LnrlpOXV9GaW8RZM=
+  dependencies:
+    babel-helper-regex "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+
+babel-plugin-transform-es2015-template-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz"
+  integrity sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz"
+  integrity sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz"
+  integrity sha1-jZzCfn7h3s/mVFT7mGRSoEphPSA=
+  dependencies:
+    babel-helper-regex "^6.22.0"
+    babel-runtime "^6.22.0"
+    regexpu-core "^2.0.0"
+
+babel-plugin-transform-exponentiation-operator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz"
+  integrity sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-inline-consecutive-adds@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz"
+  integrity sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE=
+
+babel-plugin-transform-member-expression-literals@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz"
+  integrity sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=
+
+babel-plugin-transform-merge-sibling-variables@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz"
+  integrity sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=
+
+babel-plugin-transform-minify-booleans@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz"
+  integrity sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=
+
+babel-plugin-transform-property-literals@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz"
+  integrity sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=
+  dependencies:
+    esutils "^2.0.2"
+
+babel-plugin-transform-regenerator@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz"
+  integrity sha1-ZXQFk6MZxEUiFXU41pC4QJRhfqY=
+  dependencies:
+    regenerator-transform "0.9.8"
+
+babel-plugin-transform-regexp-constructors@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz"
+  integrity sha1-WLd3W2OvzzMyj66aX4j71PsLSWU=
+
+babel-plugin-transform-remove-console@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz"
+  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
+
+babel-plugin-transform-remove-debugger@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz"
+  integrity sha1-QrcnYxyXl44estGZp67IShgznvI=
+
+babel-plugin-transform-remove-undefined@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz"
+  integrity sha512-+M7fJYFaEE/M9CXa0/IRkDbiV3wRELzA1kKQFCJ4ifhrzLKn/9VCCgj9OFmYWwBd8IB48YdgPkHYtbYq+4vtHQ==
+  dependencies:
+    babel-helper-evaluate-path "^0.5.0"
+
+babel-plugin-transform-simplify-comparison-operators@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz"
+  integrity sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=
+
+babel-plugin-transform-strict-mode@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
+  integrity sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-undefined-to-void@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz"
+  integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
+
+babel-preset-env@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz"
+  integrity sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^2.1.2"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-preset-minify@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz"
+  integrity sha512-1IajDumYOAPYImkHbrKeiN5AKKP9iOmRoO2IPbIuVp0j2iuCcj0n7P260z38siKMZZ+85d3mJZdtW8IgOv+Tzg==
+  dependencies:
+    babel-plugin-minify-builtins "^0.5.0"
+    babel-plugin-minify-constant-folding "^0.5.0"
+    babel-plugin-minify-dead-code-elimination "^0.5.1"
+    babel-plugin-minify-flip-comparisons "^0.4.3"
+    babel-plugin-minify-guarded-expressions "^0.4.4"
+    babel-plugin-minify-infinity "^0.4.3"
+    babel-plugin-minify-mangle-names "^0.5.0"
+    babel-plugin-minify-numeric-literals "^0.4.3"
+    babel-plugin-minify-replace "^0.5.0"
+    babel-plugin-minify-simplify "^0.5.1"
+    babel-plugin-minify-type-constructors "^0.4.3"
+    babel-plugin-transform-inline-consecutive-adds "^0.4.3"
+    babel-plugin-transform-member-expression-literals "^6.9.4"
+    babel-plugin-transform-merge-sibling-variables "^6.9.4"
+    babel-plugin-transform-minify-booleans "^6.9.4"
+    babel-plugin-transform-property-literals "^6.9.4"
+    babel-plugin-transform-regexp-constructors "^0.4.3"
+    babel-plugin-transform-remove-console "^6.9.4"
+    babel-plugin-transform-remove-debugger "^6.9.4"
+    babel-plugin-transform-remove-undefined "^0.5.0"
+    babel-plugin-transform-simplify-comparison-operators "^6.9.4"
+    babel-plugin-transform-undefined-to-void "^6.9.4"
+    lodash "^4.17.11"
+
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz"
+  integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
+  dependencies:
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    home-or-tmp "^2.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.15"
+
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+  integrity sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
+babel-template@6.16.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+  integrity sha1-4UndGp8Do1+BfdvE0EgZiOfryMo=
+  dependencies:
+    babel-runtime "^6.9.0"
+    babel-traverse "^6.16.0"
+    babel-types "^6.16.0"
+    babylon "^6.11.0"
+    lodash "^4.2.0"
+
+babel-template@^6.22.0, babel-template@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
+  integrity sha1-BNTycK27OqcEqBQ64m+qUpI45jg=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
+    babylon "^6.11.0"
+    lodash "^4.2.0"
+
+babel-template@^6.24.1, babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
+  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.0.20, babel-traverse@^6.16.0, babel-traverse@^6.23.0:
+  version "6.23.1"
+  resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz"
+  integrity sha1-08tZAQ7NBql9gTEAZflmtpnhT0g=
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.23.0"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz"
+  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@6.16.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz"
+  integrity sha1-ccyh2+Uzd2YiXFwZMHHo68vP/P4=
+  dependencies:
+    babel-runtime "^6.9.1"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babel-types@6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
+  integrity sha1-oTaHncFbNga9oNkMH8dDBML/CXU=
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babel-types@6.25.0:
+  version "6.25.0"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+  integrity sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babel-types@^6.0.19, babel-types@^6.16.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+  integrity sha1-uxcXnXU4utOM0MnhFdNA935+ms8=
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babel-types@^6.24.1, babel-types@^6.25.0, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
+  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babel@6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz"
+  integrity sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=
+
+babylon@6.11.2, babylon@^6.11.0:
+  version "6.11.2"
+  resolved "https://registry.npmjs.org/babylon/-/babylon-6.11.2.tgz"
+  integrity sha1-OmQ2H+3ubZ+CdqmrwMiKnlI3/3o=
+
+babylon@^6.0.18, babylon@^6.15.0:
+  version "6.16.1"
+  resolved "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz"
+  integrity sha1-MMWiL0gZeKnn+M399JaxHZS0BNM=
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-js@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+  integrity sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=
+
+base64-js@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
+  integrity sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.npmjs.org/base/-/base-0.11.2.tgz"
+  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
+  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+  dependencies:
+    tweetnacl "^0.14.3"
+
+beeper@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz"
+  integrity sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=
+
+bin-build@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz"
+  integrity sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=
+  dependencies:
+    archive-type "^3.0.1"
+    decompress "^3.0.0"
+    download "^4.1.2"
+    exec-series "^1.0.0"
+    rimraf "^2.2.6"
+    tempfile "^1.0.0"
+    url-regex "^3.0.0"
+
+binary-extensions@^1.0.0:
+  version "1.12.0"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz"
+  integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bl@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz"
+  integrity sha1-E5fn7ELF9dw4dHDFAONKn2vp6pg=
+  dependencies:
+    readable-stream "^2.0.5"
+
+bl@~0.8.1:
+  version "0.8.2"
+  resolved "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz"
+  integrity sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=
+  dependencies:
+    readable-stream "~1.0.26"
+
+bl@~0.9.0:
+  version "0.9.5"
+  resolved "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
+  integrity sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=
+  dependencies:
+    readable-stream "~1.0.26"
+
+bluebird@^3.5.4:
+  version "3.5.5"
+  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
+  version "4.11.6"
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+  integrity sha1-UzRK2xRhehP26N0s4okF0cC6MhU=
+
+body@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/body/-/body-5.1.0.tgz"
+  integrity sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=
+  dependencies:
+    continuable-cache "^0.3.1"
+    error "^7.0.0"
+    raw-body "~1.1.0"
+    safe-json-parse "~1.0.1"
+
+boom@0.4.x:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+  integrity sha1-emNune1O/O+xnO9JR6PGffrukRs=
+  dependencies:
+    hoek "0.9.x"
+
+boom@2.x.x:
+  version "2.10.1"
+  resolved "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+  integrity sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=
+  dependencies:
+    hoek "2.x.x"
+
+brace-expansion@^1.0.0:
+  version "1.1.11"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+  integrity sha1-wHshHHyVLsH479Uad+8NHTmQopI=
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+braces@^1.8.2:
+  version "1.8.5"
+  resolved "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+  integrity sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=
+  dependencies:
+    expand-range "^1.8.1"
+    preserve "^0.2.0"
+    repeat-element "^1.1.2"
+
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
+brorand@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
+browser-resolve@^1.11.0:
+  version "1.11.2"
+  resolved "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
+  integrity sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=
+  dependencies:
+    resolve "1.1.7"
+
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
+  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
+
+browserify-aes@^1.0.0, browserify-aes@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
+  integrity sha1-Xncl297x/Vkw1OurSFZ85FHEigo=
+  dependencies:
+    buffer-xor "^1.0.2"
+    cipher-base "^1.0.0"
+    create-hash "^1.1.0"
+    evp_bytestokey "^1.0.0"
+    inherits "^2.0.1"
+
+browserify-cipher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
+  integrity sha1-mYgkSHS/XtTijalWZtzWasj8Njo=
+  dependencies:
+    browserify-aes "^1.0.4"
+    browserify-des "^1.0.0"
+    evp_bytestokey "^1.0.0"
+
+browserify-des@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
+  integrity sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=
+  dependencies:
+    cipher-base "^1.0.1"
+    des.js "^1.0.0"
+    inherits "^2.0.1"
+
+browserify-fs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/browserify-fs/-/browserify-fs-1.0.0.tgz"
+  integrity sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8=
+  dependencies:
+    level-filesystem "^1.0.1"
+    level-js "^2.1.3"
+    levelup "^0.18.2"
+
+browserify-rsa@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
+  integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
+  dependencies:
+    bn.js "^4.1.0"
+    randombytes "^2.0.1"
+
+browserify-sign@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz"
+  integrity sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
+  dependencies:
+    bn.js "^4.1.1"
+    browserify-rsa "^4.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.2"
+    elliptic "^6.0.0"
+    inherits "^2.0.1"
+    parse-asn1 "^5.0.0"
+
+browserslist@^2.1.2:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz"
+  integrity sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==
+  dependencies:
+    caniuse-lite "^1.0.30000718"
+    electron-to-chromium "^1.3.18"
+
+browserslist@^4.16.6:
+  version "4.16.8"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz"
+  integrity sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==
+  dependencies:
+    caniuse-lite "^1.0.30001251"
+    colorette "^1.3.0"
+    electron-to-chromium "^1.3.811"
+    escalade "^3.1.1"
+    node-releases "^1.1.75"
+
+buf-compare@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz"
+  integrity sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
+buffer-es6@^4.9.1, buffer-es6@^4.9.2:
+  version "4.9.3"
+  resolved "https://registry.npmjs.org/buffer-es6/-/buffer-es6-4.9.3.tgz"
+  integrity sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ=
+
+buffer-shims@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+  integrity sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=
+
+buffer-to-vinyl@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz"
+  integrity sha1-APFfruOreh3aLN5tkSG//dB7ImI=
+  dependencies:
+    file-type "^3.1.0"
+    readable-stream "^2.0.2"
+    uuid "^2.0.1"
+    vinyl "^1.0.0"
+
+buffer-xor@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+  integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
+buffer@^3.0.1:
+  version "3.6.0"
+  resolved "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
+  integrity sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=
+  dependencies:
+    base64-js "0.0.8"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
+builtin-modules@^1.1.0, builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
+
+bytes@1:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+  integrity sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz"
+  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
+cache-point@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz"
+  integrity sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==
+  dependencies:
+    array-back "^2.0.0"
+    fs-then-native "^2.0.0"
+    mkdirp2 "^1.0.3"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
+  integrity sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+  integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+caniuse-lite@^1.0.30000718:
+  version "1.0.30000733"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000733.tgz"
+  integrity sha1-6/xIJUEXzAxmGXpFNstDl6bPvM0=
+
+caniuse-lite@^1.0.30001251:
+  version "1.0.30001252"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz"
+  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
+
+capture-stack-trace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
+  integrity sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+caseless@~0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+  integrity sha1-W8oogdQUN/VLJAfr40iIx7mtT30=
+
+catharsis@^0.8.11:
+  version "0.8.11"
+  resolved "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz"
+  integrity sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==
+  dependencies:
+    lodash "^4.17.14"
+
+caw@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz"
+  integrity sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=
+  dependencies:
+    get-proxy "^1.0.1"
+    is-obj "^1.0.0"
+    object-assign "^3.0.0"
+    tunnel-agent "^0.4.0"
+
+caw@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz"
+  integrity sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==
+  dependencies:
+    get-proxy "^2.0.0"
+    isurl "^1.0.0-alpha5"
+    tunnel-agent "^0.6.0"
+    url-to-options "^1.0.1"
+
+chalk@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
+  integrity sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=
+  dependencies:
+    ansi-styles "^1.1.0"
+    escape-string-regexp "^1.0.0"
+    has-ansi "^0.1.0"
+    strip-ansi "^0.3.0"
+    supports-color "^0.2.0"
+
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
+chalk@^2.0.0:
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chokidar@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz"
+  integrity sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=
+  dependencies:
+    anymatch "^1.3.0"
+    async-each "^1.0.0"
+    glob-parent "^2.0.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^2.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
   optionalDependencies:
-    "fsevents" "^1.0.0"
-
-"cipher-base@^1.0.0", "cipher-base@^1.0.1":
-  "integrity" "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc="
-  "resolved" "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
-  "version" "1.0.3"
-  dependencies:
-    "inherits" "^2.0.1"
-
-"circular-json@^0.3.1":
-  "integrity" "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0="
-  "resolved" "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
-  "version" "0.3.1"
-
-"class-utils@^0.3.5":
-  "integrity" "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg=="
-  "resolved" "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz"
-  "version" "0.3.6"
-  dependencies:
-    "arr-union" "^3.1.0"
-    "define-property" "^0.2.5"
-    "isobject" "^3.0.0"
-    "static-extend" "^0.1.1"
-
-"cli-cursor@^1.0.1":
-  "integrity" "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
-  "resolved" "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "restore-cursor" "^1.0.1"
-
-"cli-width@^2.0.0":
-  "integrity" "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
-  "resolved" "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
-  "version" "2.1.0"
-
-"clone-stats@^0.0.1":
-  "integrity" "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-  "resolved" "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-  "version" "0.0.1"
-
-"clone@^0.2.0":
-  "integrity" "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
-  "resolved" "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-  "version" "0.2.0"
-
-"clone@^1.0.0":
-  "integrity" "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
-  "resolved" "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-  "version" "1.0.2"
-
-"clone@~0.1.9":
-  "integrity" "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU="
-  "resolved" "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
-  "version" "0.1.19"
-
-"co@^4.6.0":
-  "integrity" "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-  "resolved" "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-  "version" "4.6.0"
-
-"co@3.1.0":
-  "integrity" "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-  "resolved" "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
-  "version" "3.1.0"
-
-"code-point-at@^1.0.0":
-  "integrity" "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-  "resolved" "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-  "version" "1.1.0"
-
-"collect-all@^1.0.3":
-  "integrity" "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA=="
-  "resolved" "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz"
-  "version" "1.0.3"
-  dependencies:
-    "stream-connect" "^1.0.2"
-    "stream-via" "^1.0.4"
-
-"collection-visit@^1.0.0":
-  "integrity" "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA="
-  "resolved" "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "map-visit" "^1.0.0"
-    "object-visit" "^1.0.0"
-
-"color-convert@^1.9.0":
-  "integrity" "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="
-  "resolved" "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
-  "version" "1.9.3"
-  dependencies:
-    "color-name" "1.1.3"
-
-"color-name@1.1.3":
-  "integrity" "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-  "resolved" "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  "version" "1.1.3"
-
-"colorette@^1.3.0":
-  "integrity" "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
-  "resolved" "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz"
-  "version" "1.3.0"
-
-"colors@1.0.3":
-  "integrity" "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-  "resolved" "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-  "version" "1.0.3"
-
-"combined-stream@^1.0.5", "combined-stream@~1.0.5":
-  "integrity" "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w=="
-  "resolved" "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz"
-  "version" "1.0.7"
-  dependencies:
-    "delayed-stream" "~1.0.0"
-
-"combined-stream@~0.0.4", "combined-stream@~0.0.5":
-  "integrity" "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8="
-  "resolved" "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
-  "version" "0.0.7"
-  dependencies:
-    "delayed-stream" "0.0.5"
-
-"command-line-args@^5.0.0":
-  "integrity" "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg=="
-  "resolved" "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz"
-  "version" "5.1.1"
-  dependencies:
-    "array-back" "^3.0.1"
-    "find-replace" "^3.0.0"
-    "lodash.camelcase" "^4.3.0"
-    "typical" "^4.0.0"
-
-"command-line-tool@^0.8.0":
-  "integrity" "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g=="
-  "resolved" "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz"
-  "version" "0.8.0"
-  dependencies:
-    "ansi-escape-sequences" "^4.0.0"
-    "array-back" "^2.0.0"
-    "command-line-args" "^5.0.0"
-    "command-line-usage" "^4.1.0"
-    "typical" "^2.6.1"
-
-"command-line-usage@^4.1.0":
-  "integrity" "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g=="
-  "resolved" "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz"
-  "version" "4.1.0"
-  dependencies:
-    "ansi-escape-sequences" "^4.0.0"
-    "array-back" "^2.0.0"
-    "table-layout" "^0.4.2"
-    "typical" "^2.6.1"
-
-"command-line-usage@4.0.0":
-  "integrity" "sha1-gWsyeItY+f66RNHm2sYPyuspteo="
-  "resolved" "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "ansi-escape-sequences" "^3.0.0"
-    "array-back" "^1.0.4"
-    "table-layout" "^0.4.0"
-    "typical" "^2.6.0"
-
-"commander@~2.8.1":
-  "integrity" "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ="
-  "resolved" "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
-  "version" "2.8.1"
-  dependencies:
-    "graceful-readlink" ">= 1.0.0"
-
-"commander@2.6.0":
-  "integrity" "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0="
-  "resolved" "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
-  "version" "2.6.0"
-
-"commander@2.9.0":
-  "integrity" "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
-  "resolved" "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-  "version" "2.9.0"
-  dependencies:
-    "graceful-readlink" ">= 1.0.0"
-
-"common-sequence@^1.0.2":
-  "integrity" "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg="
-  "resolved" "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz"
-  "version" "1.0.2"
-
-"component-emitter@^1.2.1":
-  "integrity" "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-  "resolved" "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
-  "version" "1.2.1"
-
-"concat-map@0.0.1":
-  "integrity" "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-  "resolved" "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-  "version" "0.0.1"
-
-"concat-stream@^1.4.4", "concat-stream@^1.4.6", "concat-stream@^1.4.7":
-  "integrity" "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
-  "resolved" "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz"
-  "version" "1.6.0"
-  dependencies:
-    "inherits" "^2.0.3"
-    "readable-stream" "^2.2.2"
-    "typedarray" "^0.0.6"
-
-"concurrently@3.5.0":
-  "integrity" "sha1-jPG3cHppFqeKT/W3e7BN7FSzebI="
-  "resolved" "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz"
-  "version" "3.5.0"
-  dependencies:
-    "chalk" "0.5.1"
-    "commander" "2.6.0"
-    "date-fns" "^1.23.0"
-    "lodash" "^4.5.1"
-    "rx" "2.3.24"
-    "spawn-command" "^0.0.2-1"
-    "supports-color" "^3.2.3"
-    "tree-kill" "^1.1.0"
-
-"config-chain@^1.1.11":
-  "integrity" "sha1-q6CXR9++TD5w52am5BWG4YWfxvI="
-  "resolved" "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz"
-  "version" "1.1.11"
-  dependencies:
-    "ini" "^1.3.4"
-    "proto-list" "~1.2.1"
-
-"config-master@^3.1.0":
-  "integrity" "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo="
-  "resolved" "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "walk-back" "^2.0.1"
-
-"contains-path@^0.1.0":
-  "integrity" "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
-  "resolved" "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz"
-  "version" "0.1.0"
-
-"content-disposition@^0.5.2":
-  "integrity" "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-  "resolved" "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
-  "version" "0.5.2"
-
-"continuable-cache@^0.3.1":
-  "integrity" "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8="
-  "resolved" "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz"
-  "version" "0.3.1"
-
-"convert-source-map@^1.1.1", "convert-source-map@^1.5.0":
-  "integrity" "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
-  "resolved" "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
-  "version" "1.5.0"
-
-"convert-source-map@^1.7.0":
-  "integrity" "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA=="
-  "resolved" "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz"
-  "version" "1.8.0"
-  dependencies:
-    "safe-buffer" "~5.1.1"
-
-"copy-descriptor@^0.1.0":
-  "integrity" "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-  "resolved" "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
-  "version" "0.1.1"
-
-"core-assert@^0.2.0":
-  "integrity" "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8="
-  "resolved" "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz"
-  "version" "0.2.1"
-  dependencies:
-    "buf-compare" "^1.0.0"
-    "is-error" "^2.2.0"
-
-"core-js@^2.0.0", "core-js@^2.4.0":
-  "integrity" "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
-  "resolved" "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-  "version" "2.4.1"
-
-"core-js@^2.4.1":
-  "integrity" "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
-  "resolved" "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz"
-  "version" "2.5.0"
-
-"core-js@^2.5.0":
-  "integrity" "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
-  "resolved" "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz"
-  "version" "2.5.0"
-
-"core-util-is@~1.0.0", "core-util-is@1.0.2":
-  "integrity" "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-  "resolved" "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-  "version" "1.0.2"
-
-"corser@~2.0.0":
-  "integrity" "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
-  "resolved" "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz"
-  "version" "2.0.1"
-
-"create-ecdh@^4.0.0":
-  "integrity" "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30="
-  "resolved" "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "bn.js" "^4.1.0"
-    "elliptic" "^6.0.0"
-
-"create-error-class@^3.0.1":
-  "integrity" "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y="
-  "resolved" "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
-  "version" "3.0.2"
-  dependencies:
-    "capture-stack-trace" "^1.0.0"
-
-"create-hash@^1.1.0", "create-hash@^1.1.1":
-  "integrity" "sha1-USEAYte7dHn2xlu0GpIgix1hq60="
-  "resolved" "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
-  "version" "1.1.2"
-  dependencies:
-    "cipher-base" "^1.0.1"
-    "inherits" "^2.0.1"
-    "ripemd160" "^1.0.0"
-    "sha.js" "^2.3.6"
-
-"create-hmac@^1.1.0", "create-hmac@^1.1.2":
-  "integrity" "sha1-0/tLolPriz9W456i+8uK90e9MXA="
-  "resolved" "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
-  "version" "1.1.4"
-  dependencies:
-    "create-hash" "^1.1.0"
-    "inherits" "^2.0.1"
-
-"cryptiles@0.2.x":
-  "integrity" "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw="
-  "resolved" "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-  "version" "0.2.2"
-  dependencies:
-    "boom" "0.4.x"
-
-"cryptiles@2.x.x":
-  "integrity" "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
-  "resolved" "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-  "version" "2.0.5"
-  dependencies:
-    "boom" "2.x.x"
-
-"crypto-browserify@^3.11.0":
-  "integrity" "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI="
-  "resolved" "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
-  "version" "3.11.0"
-  dependencies:
-    "browserify-cipher" "^1.0.0"
-    "browserify-sign" "^4.0.0"
-    "create-ecdh" "^4.0.0"
-    "create-hash" "^1.1.0"
-    "create-hmac" "^1.1.0"
-    "diffie-hellman" "^5.0.0"
-    "inherits" "^2.0.1"
-    "pbkdf2" "^3.0.3"
-    "public-encrypt" "^4.0.0"
-    "randombytes" "^2.0.0"
-
-"crypto-browserify@1.0.9":
-  "integrity" "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
-  "resolved" "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
-  "version" "1.0.9"
-
-"ctype@0.5.3":
-  "integrity" "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
-  "resolved" "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-  "version" "0.5.3"
-
-"d@1":
-  "integrity" "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
-  "resolved" "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "es5-ext" "^0.10.9"
-
-"damerau-levenshtein@^1.0.0":
-  "integrity" "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
-  "resolved" "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz"
-  "version" "1.0.4"
-
-"dashdash@^1.12.0":
-  "integrity" "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
-  "resolved" "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-  "version" "1.14.1"
-  dependencies:
-    "assert-plus" "^1.0.0"
-
-"date-fns@^1.23.0":
-  "integrity" "sha1-JXz8RdMi30XvVlhmWWfuhBzXP68="
-  "resolved" "https://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz"
-  "version" "1.28.5"
-
-"dateformat@^2.0.0":
-  "integrity" "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
-  "resolved" "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz"
-  "version" "2.0.0"
-
-"debug@^2.1.1":
-  "integrity" "sha1-D364wwll7AjHKsz6ATDIt5mEFB0="
-  "resolved" "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz"
-  "version" "2.6.3"
-  dependencies:
-    "ms" "0.7.2"
-
-"debug@^2.2.0", "debug@^2.3.3":
-  "integrity" "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
-  "resolved" "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-  "version" "2.6.9"
-  dependencies:
-    "ms" "2.0.0"
-
-"debug@^2.6.8":
-  "integrity" "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
-  "resolved" "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
-  "version" "2.6.8"
-  dependencies:
-    "ms" "2.0.0"
-
-"debug@^4.1.0":
-  "integrity" "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw=="
-  "resolved" "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz"
-  "version" "4.3.2"
-  dependencies:
-    "ms" "2.1.2"
-
-"debug@~2.6.7":
-  "integrity" "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
-  "resolved" "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
-  "version" "2.6.8"
-  dependencies:
-    "ms" "2.0.0"
-
-"debug@2.6.8":
-  "integrity" "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
-  "resolved" "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
-  "version" "2.6.8"
-  dependencies:
-    "ms" "2.0.0"
-
-"decode-uri-component@^0.2.0":
-  "integrity" "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-  "resolved" "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
-  "version" "0.2.0"
-
-"decompress-response@^3.2.0":
-  "integrity" "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M="
-  "resolved" "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz"
-  "version" "3.3.0"
-  dependencies:
-    "mimic-response" "^1.0.0"
-
-"decompress-tar@^3.0.0":
-  "integrity" "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY="
-  "resolved" "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "is-tar" "^1.0.0"
-    "object-assign" "^2.0.0"
-    "strip-dirs" "^1.0.0"
-    "tar-stream" "^1.1.1"
-    "through2" "^0.6.1"
-    "vinyl" "^0.4.3"
-
-"decompress-tar@^4.0.0", "decompress-tar@^4.1.0", "decompress-tar@^4.1.1":
-  "integrity" "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ=="
-  "resolved" "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz"
-  "version" "4.1.1"
-  dependencies:
-    "file-type" "^5.2.0"
-    "is-stream" "^1.1.0"
-    "tar-stream" "^1.5.2"
-
-"decompress-tarbz2@^3.0.0":
-  "integrity" "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0="
-  "resolved" "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "is-bzip2" "^1.0.0"
-    "object-assign" "^2.0.0"
-    "seek-bzip" "^1.0.3"
-    "strip-dirs" "^1.0.0"
-    "tar-stream" "^1.1.1"
-    "through2" "^0.6.1"
-    "vinyl" "^0.4.3"
-
-"decompress-tarbz2@^4.0.0":
-  "integrity" "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A=="
-  "resolved" "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz"
-  "version" "4.1.1"
-  dependencies:
-    "decompress-tar" "^4.1.0"
-    "file-type" "^6.1.0"
-    "is-stream" "^1.1.0"
-    "seek-bzip" "^1.0.5"
-    "unbzip2-stream" "^1.0.9"
-
-"decompress-targz@^3.0.0":
-  "integrity" "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA="
-  "resolved" "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "is-gzip" "^1.0.0"
-    "object-assign" "^2.0.0"
-    "strip-dirs" "^1.0.0"
-    "tar-stream" "^1.1.1"
-    "through2" "^0.6.1"
-    "vinyl" "^0.4.3"
-
-"decompress-targz@^4.0.0":
-  "integrity" "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w=="
-  "resolved" "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz"
-  "version" "4.1.1"
-  dependencies:
-    "decompress-tar" "^4.1.1"
-    "file-type" "^5.2.0"
-    "is-stream" "^1.1.0"
-
-"decompress-unzip@^3.0.0":
-  "integrity" "sha1-YUdbQVIGa74/7hL51inRX+ZHjus="
-  "resolved" "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz"
-  "version" "3.4.0"
-  dependencies:
-    "is-zip" "^1.0.0"
-    "read-all-stream" "^3.0.0"
-    "stat-mode" "^0.2.0"
-    "strip-dirs" "^1.0.0"
-    "through2" "^2.0.0"
-    "vinyl" "^1.0.0"
-    "yauzl" "^2.2.1"
-
-"decompress-unzip@^4.0.1":
-  "integrity" "sha1-3qrM39FK6vhVePczroIQ+bSEj2k="
-  "resolved" "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz"
-  "version" "4.0.1"
-  dependencies:
-    "file-type" "^3.8.0"
-    "get-stream" "^2.2.0"
-    "pify" "^2.3.0"
-    "yauzl" "^2.4.2"
-
-"decompress@^3.0.0":
-  "integrity" "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0="
-  "resolved" "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "buffer-to-vinyl" "^1.0.0"
-    "concat-stream" "^1.4.6"
-    "decompress-tar" "^3.0.0"
-    "decompress-tarbz2" "^3.0.0"
-    "decompress-targz" "^3.0.0"
-    "decompress-unzip" "^3.0.0"
-    "stream-combiner2" "^1.1.1"
-    "vinyl-assign" "^1.0.1"
-    "vinyl-fs" "^2.2.0"
-
-"decompress@^4.0.0":
-  "integrity" "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50="
-  "resolved" "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz"
-  "version" "4.2.0"
-  dependencies:
-    "decompress-tar" "^4.0.0"
-    "decompress-tarbz2" "^4.0.0"
-    "decompress-targz" "^4.0.0"
-    "decompress-unzip" "^4.0.1"
-    "graceful-fs" "^4.1.10"
-    "make-dir" "^1.0.0"
-    "pify" "^2.3.0"
-    "strip-dirs" "^2.0.0"
-
-"deep-extend@~0.4.0":
-  "integrity" "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-  "resolved" "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
-  "version" "0.4.2"
-
-"deep-extend@~0.4.1":
-  "integrity" "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
-  "resolved" "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-  "version" "0.4.1"
-
-"deep-extend@~0.6.0":
-  "integrity" "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-  "resolved" "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
-  "version" "0.6.0"
-
-"deep-is@~0.1.3":
-  "integrity" "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-  "resolved" "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-  "version" "0.1.3"
-
-"deep-strict-equal@^0.2.0":
-  "integrity" "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ="
-  "resolved" "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz"
-  "version" "0.2.0"
-  dependencies:
-    "core-assert" "^0.2.0"
-
-"deferred-leveldown@~0.2.0":
-  "integrity" "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ="
-  "resolved" "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz"
-  "version" "0.2.0"
-  dependencies:
-    "abstract-leveldown" "~0.12.1"
-
-"define-properties@^1.1.2":
-  "integrity" "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ="
-  "resolved" "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz"
-  "version" "1.1.2"
-  dependencies:
-    "foreach" "^2.0.5"
-    "object-keys" "^1.0.8"
-
-"define-property@^0.2.5":
-  "integrity" "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY="
-  "resolved" "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz"
-  "version" "0.2.5"
-  dependencies:
-    "is-descriptor" "^0.1.0"
-
-"define-property@^1.0.0":
-  "integrity" "sha1-dp66rz9KY6rTr56NMEybvnm/sOY="
-  "resolved" "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "is-descriptor" "^1.0.0"
-
-"define-property@^2.0.2":
-  "integrity" "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ=="
-  "resolved" "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz"
-  "version" "2.0.2"
-  dependencies:
-    "is-descriptor" "^1.0.2"
-    "isobject" "^3.0.1"
-
-"del@^2.0.2":
-  "integrity" "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag="
-  "resolved" "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
-  "version" "2.2.2"
-  dependencies:
-    "globby" "^5.0.0"
-    "is-path-cwd" "^1.0.0"
-    "is-path-in-cwd" "^1.0.0"
-    "object-assign" "^4.0.1"
-    "pify" "^2.0.0"
-    "pinkie-promise" "^2.0.0"
-    "rimraf" "^2.2.8"
-
-"delayed-stream@~1.0.0":
-  "integrity" "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-  "resolved" "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-  "version" "1.0.0"
-
-"delayed-stream@0.0.5":
-  "integrity" "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
-  "resolved" "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-  "version" "0.0.5"
-
-"des.js@^1.0.0":
-  "integrity" "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw="
-  "resolved" "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "inherits" "^2.0.1"
-    "minimalistic-assert" "^1.0.0"
-
-"detect-indent@^3.0.1":
-  "integrity" "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U="
-  "resolved" "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
-  "version" "3.0.1"
-  dependencies:
-    "get-stdin" "^4.0.1"
-    "minimist" "^1.1.0"
-    "repeating" "^1.1.0"
-
-"detect-indent@^4.0.0":
-  "integrity" "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
-  "resolved" "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "repeating" "^2.0.0"
-
-"diff@3.2.0":
-  "integrity" "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-  "resolved" "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
-  "version" "3.2.0"
-
-"diffie-hellman@^5.0.0":
-  "integrity" "sha1-tYNXOScM/ias9jIJn97SoH8gnl4="
-  "resolved" "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
-  "version" "5.0.2"
-  dependencies:
-    "bn.js" "^4.1.0"
-    "miller-rabin" "^4.0.0"
-    "randombytes" "^2.0.0"
-
-"dmd@^4.0.2":
-  "integrity" "sha512-qU9jcZQCxfLlTbZU1e5jROXVkTsn9q3s1FmnOPFWo9tfDol3cSt0AZREiXCsgmSaS5L/AXXQqcZiR7YjFNAL1g=="
-  "resolved" "https://registry.npmjs.org/dmd/-/dmd-4.0.3.tgz"
-  "version" "4.0.3"
-  dependencies:
-    "array-back" "^4.0.0"
-    "cache-point" "^0.4.1"
-    "common-sequence" "^1.0.2"
-    "file-set" "^2.0.1"
-    "handlebars" "^4.2.0"
-    "marked" "^0.7.0"
-    "object-get" "^2.1.0"
-    "reduce-flatten" "^2.0.0"
-    "reduce-unique" "^2.0.1"
-    "reduce-without" "^1.0.1"
-    "test-value" "^3.0.0"
-    "walk-back" "^3.0.1"
-
-"doctrine@^1.2.2":
-  "integrity" "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo="
-  "resolved" "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz"
-  "version" "1.5.0"
-  dependencies:
-    "esutils" "^2.0.2"
-    "isarray" "^1.0.0"
-
-"doctrine@1.2.x":
-  "integrity" "sha1-auxrvWLPid1JjK5wwO2fSdqHOmo="
-  "resolved" "https://registry.npmjs.org/doctrine/-/doctrine-1.2.3.tgz"
-  "version" "1.2.3"
-  dependencies:
-    "esutils" "^2.0.2"
-    "isarray" "^1.0.0"
-
-"download@^4.1.2":
-  "integrity" "sha1-qlX9rTktldS2jowr4D4MKqIbqaw="
-  "resolved" "https://registry.npmjs.org/download/-/download-4.4.3.tgz"
-  "version" "4.4.3"
-  dependencies:
-    "caw" "^1.0.1"
-    "concat-stream" "^1.4.7"
-    "each-async" "^1.0.0"
-    "filenamify" "^1.0.1"
-    "got" "^5.0.0"
-    "gulp-decompress" "^1.2.0"
-    "gulp-rename" "^1.2.0"
-    "is-url" "^1.2.0"
-    "object-assign" "^4.0.1"
-    "read-all-stream" "^3.0.0"
-    "readable-stream" "^2.0.2"
-    "stream-combiner2" "^1.1.1"
-    "vinyl" "^1.0.0"
-    "vinyl-fs" "^2.2.0"
-    "ware" "^1.2.0"
-
-"download@^6.0.0":
-  "integrity" "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA=="
-  "resolved" "https://registry.npmjs.org/download/-/download-6.2.5.tgz"
-  "version" "6.2.5"
-  dependencies:
-    "caw" "^2.0.0"
-    "content-disposition" "^0.5.2"
-    "decompress" "^4.0.0"
-    "ext-name" "^5.0.0"
-    "file-type" "5.2.0"
-    "filenamify" "^2.0.0"
-    "get-stream" "^3.0.0"
-    "got" "^7.0.0"
-    "make-dir" "^1.0.0"
-    "p-event" "^1.0.0"
-    "pify" "^3.0.0"
-
-"duplexer2@^0.1.4", "duplexer2@~0.1.0":
-  "integrity" "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME="
-  "resolved" "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
-  "version" "0.1.4"
-  dependencies:
-    "readable-stream" "^2.0.2"
-
-"duplexer2@0.0.2":
-  "integrity" "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds="
-  "resolved" "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
-  "version" "0.0.2"
-  dependencies:
-    "readable-stream" "~1.1.9"
-
-"duplexer3@^0.1.4":
-  "integrity" "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-  "resolved" "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz"
-  "version" "0.1.4"
-
-"duplexify@^3.2.0":
-  "integrity" "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ="
-  "resolved" "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz"
-  "version" "3.5.0"
-  dependencies:
-    "end-of-stream" "1.0.0"
-    "inherits" "^2.0.1"
-    "readable-stream" "^2.0.0"
-    "stream-shift" "^1.0.0"
-
-"each-async@^1.0.0":
-  "integrity" "sha1-3uUim98KtrogEqOV4bhpq/iBNHM="
-  "resolved" "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz"
-  "version" "1.1.1"
-  dependencies:
-    "onetime" "^1.0.0"
-    "set-immediate-shim" "^1.0.0"
-
-"ecc-jsbn@~0.1.1":
-  "integrity" "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk="
-  "resolved" "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
-  "version" "0.1.2"
-  dependencies:
-    "jsbn" "~0.1.0"
-    "safer-buffer" "^2.1.0"
-
-"ecstatic@^2.0.0":
-  "integrity" "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ=="
-  "resolved" "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz"
-  "version" "2.2.1"
-  dependencies:
-    "he" "^1.1.1"
-    "mime" "^1.2.11"
-    "minimist" "^1.1.0"
-    "url-join" "^2.0.2"
-
-"electron-to-chromium@^1.3.18":
-  "integrity" "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI="
-  "resolved" "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz"
-  "version" "1.3.21"
-
-"electron-to-chromium@^1.3.811":
-  "integrity" "sha512-jbwqBmqo9ZBWNfz6EKDTx66rqRDt87ZbOxtUegYNpkVMX6z93PMaFbDy7/LIPRwMI/5T4GVcYkROWDPQm9Ni7A=="
-  "resolved" "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.823.tgz"
-  "version" "1.3.823"
-
-"elliptic@^6.0.0":
-  "integrity" "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8="
-  "resolved" "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
-  "version" "6.4.0"
-  dependencies:
-    "bn.js" "^4.4.0"
-    "brorand" "^1.0.1"
-    "hash.js" "^1.0.0"
-    "hmac-drbg" "^1.0.0"
-    "inherits" "^2.0.1"
-    "minimalistic-assert" "^1.0.0"
-    "minimalistic-crypto-utils" "^1.0.0"
-
-"encoding@^0.1.11":
-  "integrity" "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
-  "resolved" "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
-  "version" "0.1.12"
-  dependencies:
-    "iconv-lite" "~0.4.13"
-
-"end-of-stream@^1.0.0":
-  "integrity" "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
-  "resolved" "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz"
-  "version" "1.4.0"
-  dependencies:
-    "once" "^1.4.0"
-
-"end-of-stream@1.0.0":
-  "integrity" "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4="
-  "resolved" "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "once" "~1.3.0"
-
-"enhance-visitors@^1.0.0":
-  "integrity" "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo="
-  "resolved" "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "lodash" "^4.13.1"
-
-"entities@~1.1.1":
-  "integrity" "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-  "resolved" "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz"
-  "version" "1.1.2"
-
-"errno@^0.1.1", "errno@~0.1.1":
-  "integrity" "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0="
-  "resolved" "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
-  "version" "0.1.4"
-  dependencies:
-    "prr" "~0.0.0"
-
-"error-ex@^1.2.0":
-  "integrity" "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
-  "resolved" "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
-  "version" "1.3.1"
-  dependencies:
-    "is-arrayish" "^0.2.1"
-
-"error@^7.0.0":
-  "integrity" "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI="
-  "resolved" "https://registry.npmjs.org/error/-/error-7.0.2.tgz"
-  "version" "7.0.2"
-  dependencies:
-    "string-template" "~0.2.1"
-    "xtend" "~4.0.0"
-
-"es-abstract@^1.5.1":
-  "integrity" "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ=="
-  "resolved" "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz"
-  "version" "1.10.0"
-  dependencies:
-    "es-to-primitive" "^1.1.1"
-    "function-bind" "^1.1.1"
-    "has" "^1.0.1"
-    "is-callable" "^1.1.3"
-    "is-regex" "^1.0.4"
-
-"es-to-primitive@^1.1.1":
-  "integrity" "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0="
-  "resolved" "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
-  "version" "1.1.1"
-  dependencies:
-    "is-callable" "^1.1.1"
-    "is-date-object" "^1.0.1"
-    "is-symbol" "^1.0.1"
-
-"es5-ext@^0.10.14", "es5-ext@^0.10.9", "es5-ext@~0.10.14":
-  "integrity" "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY="
-  "resolved" "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-  "version" "0.10.15"
-  dependencies:
-    "es6-iterator" "2"
-    "es6-symbol" "~3.1"
-
-"es6-iterator@^2.0.1", "es6-iterator@~2.0.1", "es6-iterator@2":
-  "integrity" "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI="
-  "resolved" "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "d" "1"
-    "es5-ext" "^0.10.14"
-    "es6-symbol" "^3.1"
-
-"es6-map@^0.1.3":
-  "integrity" "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA="
-  "resolved" "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz"
-  "version" "0.1.5"
-  dependencies:
-    "d" "1"
-    "es5-ext" "~0.10.14"
-    "es6-iterator" "~2.0.1"
-    "es6-set" "~0.1.5"
-    "es6-symbol" "~3.1.1"
-    "event-emitter" "~0.3.5"
-
-"es6-set@^0.1.4", "es6-set@~0.1.5":
-  "integrity" "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE="
-  "resolved" "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
-  "version" "0.1.5"
-  dependencies:
-    "d" "1"
-    "es5-ext" "~0.10.14"
-    "es6-iterator" "~2.0.1"
-    "es6-symbol" "3.1.1"
-    "event-emitter" "~0.3.5"
-
-"es6-symbol@^3.1", "es6-symbol@^3.1.1", "es6-symbol@~3.1", "es6-symbol@~3.1.1", "es6-symbol@3.1.1":
-  "integrity" "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
-  "resolved" "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-  "version" "3.1.1"
-  dependencies:
-    "d" "1"
-    "es5-ext" "~0.10.14"
-
-"es6-weak-map@^2.0.1":
-  "integrity" "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8="
-  "resolved" "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz"
-  "version" "2.0.2"
-  dependencies:
-    "d" "1"
-    "es5-ext" "^0.10.14"
-    "es6-iterator" "^2.0.1"
-    "es6-symbol" "^3.1.1"
-
-"escalade@^3.1.1":
-  "integrity" "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
-  "resolved" "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
-  "version" "3.1.1"
-
-"escape-string-regexp@^1.0.0", "escape-string-regexp@^1.0.2", "escape-string-regexp@^1.0.5", "escape-string-regexp@1.0.5":
-  "integrity" "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-  "resolved" "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-  "version" "1.0.5"
-
-"escape-string-regexp@^2.0.0":
-  "integrity" "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-  "resolved" "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz"
-  "version" "2.0.0"
-
-"escope@^3.6.0":
-  "integrity" "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM="
-  "resolved" "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
-  "version" "3.6.0"
-  dependencies:
-    "es6-map" "^0.1.3"
-    "es6-weak-map" "^2.0.1"
-    "esrecurse" "^4.1.0"
-    "estraverse" "^4.1.1"
-
-"eslint-import-resolver-node@^0.2.0":
-  "integrity" "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw="
-  "resolved" "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz"
-  "version" "0.2.3"
-  dependencies:
-    "debug" "^2.2.0"
-    "object-assign" "^4.0.1"
-    "resolve" "^1.1.6"
-
-"eslint-plugin-ava@3.0.x":
-  "integrity" "sha1-3bX8coDXlmOqz3K/d5h+GNVOV+k="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "arrify" "^1.0.1"
-    "deep-strict-equal" "^0.2.0"
-    "enhance-visitors" "^1.0.0"
-    "espree" "^3.1.3"
-    "espurify" "^1.5.0"
-    "multimatch" "^2.1.0"
-    "pkg-up" "^1.0.0"
-    "req-all" "^0.1.0"
-
-"eslint-plugin-babel@3.3.x":
-  "integrity" "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz"
-  "version" "3.3.0"
-
-"eslint-plugin-chai-expect@1.1.x":
-  "integrity" "sha1-zWQLizjPbDq8w3hnO3sXO5ndxwo="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-1.1.1.tgz"
-  "version" "1.1.1"
-
-"eslint-plugin-flowtype@2.7.x":
-  "integrity" "sha1-rNCEH9LFX4a2n1TOkyNNC9h4lKk="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.7.2.tgz"
-  "version" "2.7.2"
-  dependencies:
-    "lodash" "^4.9.0"
-
-"eslint-plugin-import@1.13.x":
-  "integrity" "sha1-DonthoOW0JEi4wft9ts3iBz93dc="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-1.13.0.tgz"
-  "version" "1.13.0"
-  dependencies:
-    "builtin-modules" "^1.1.1"
-    "contains-path" "^0.1.0"
-    "debug" "^2.2.0"
-    "doctrine" "1.2.x"
-    "es6-map" "^0.1.3"
-    "es6-set" "^0.1.4"
-    "eslint-import-resolver-node" "^0.2.0"
-    "lodash.cond" "^4.3.0"
-    "lodash.endswith" "^4.0.1"
-    "lodash.find" "^4.3.0"
-    "lodash.findindex" "^4.3.0"
-    "object-assign" "^4.0.1"
-    "pkg-dir" "^1.0.0"
-    "pkg-up" "^1.0.0"
-
-"eslint-plugin-jsx-a11y@2.1.x":
-  "integrity" "sha1-dZUkuNcWHYSad6kXNaOXTdHPwys="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.1.0.tgz"
-  "version" "2.1.0"
-  dependencies:
-    "damerau-levenshtein" "^1.0.0"
-    "jsx-ast-utils" "^1.0.0"
-    "object-assign" "^4.0.1"
-
-"eslint-plugin-lodash@1.10.x":
-  "integrity" "sha1-o0HjOGtutOS3rdz0PDp/lE84VR0="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-1.10.3.tgz"
-  "version" "1.10.3"
-  dependencies:
-    "lodash" "^4.9.0"
-
-"eslint-plugin-mocha@4.3.x":
-  "integrity" "sha1-hAdblvw3/pZ9KbhgIoU6FP8lLMM="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.3.0.tgz"
-  "version" "4.3.0"
-  dependencies:
-    "ramda" "^0.21.0"
-
-"eslint-plugin-node@2.0.x":
-  "integrity" "sha1-1J3EJ87cDfQ2I4zcsGrNlh+jjeU="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "ignore" "^3.0.11"
-    "minimatch" "^3.0.2"
-    "object-assign" "^4.0.1"
-    "resolve" "^1.1.7"
-    "semver" "5.2.0"
-
-"eslint-plugin-promise@2.0.x":
-  "integrity" "sha1-qXWc76XjirEbsu9loE7wQjCaoKQ="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-2.0.1.tgz"
-  "version" "2.0.1"
-
-"eslint-plugin-react@6.1.x":
-  "integrity" "sha1-1gIr2bzkSOUXoAOrxkCefKGADGg="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.1.2.tgz"
-  "version" "6.1.2"
-  dependencies:
-    "doctrine" "^1.2.2"
-    "jsx-ast-utils" "^1.3.1"
-
-"eslint-plugin-shopify@14.0.0":
-  "integrity" "sha1-SqbKhyN3xynlEKZwSpGA8O06D28="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-shopify/-/eslint-plugin-shopify-14.0.0.tgz"
-  "version" "14.0.0"
-  dependencies:
-    "babel-eslint" "6.1.x"
-    "eslint-plugin-ava" "3.0.x"
-    "eslint-plugin-babel" "3.3.x"
-    "eslint-plugin-chai-expect" "1.1.x"
-    "eslint-plugin-flowtype" "2.7.x"
-    "eslint-plugin-import" "1.13.x"
-    "eslint-plugin-jsx-a11y" "2.1.x"
-    "eslint-plugin-lodash" "1.10.x"
-    "eslint-plugin-mocha" "4.3.x"
-    "eslint-plugin-node" "2.0.x"
-    "eslint-plugin-promise" "2.0.x"
-    "eslint-plugin-react" "6.1.x"
-    "eslint-plugin-sort-class-members" "1.0.x"
-    "merge" "1.x"
-
-"eslint-plugin-sort-class-members@1.0.x":
-  "integrity" "sha1-svdMR9WklAxUHrVzxbwq4ct3hhA="
-  "resolved" "https://registry.npmjs.org/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.0.2.tgz"
-  "version" "1.0.2"
-
-"eslint-test-generator@1.0.5":
-  "integrity" "sha1-+KKigOj/+9LVUOU9aAeXctrv+OM="
-  "resolved" "https://registry.npmjs.org/eslint-test-generator/-/eslint-test-generator-1.0.5.tgz"
-  "version" "1.0.5"
-  dependencies:
-    "eslint" "3.3.x"
-    "glob" "^7.0.5"
-    "handlebars" "^4.0.5"
-    "js-string-escape" "^1.0.1"
-
-"eslint@^2.0.0 || ^3.0.0", "eslint@^2.10 || ^3.0", "eslint@^2.10.2 || 3.x", "eslint@>=0.8.0", "eslint@>=1.0.0", "eslint@>=1.3.0", "eslint@>=2.0.0", "eslint@>=3", "eslint@2.x - 3.x", "eslint@3.3.x", "eslint@3.8.1":
-  "integrity" "sha1-fQLbRM1ar0+nqkieHwg7qkVDQro="
-  "resolved" "https://registry.npmjs.org/eslint/-/eslint-3.8.1.tgz"
-  "version" "3.8.1"
-  dependencies:
-    "chalk" "^1.1.3"
-    "concat-stream" "^1.4.6"
-    "debug" "^2.1.1"
-    "doctrine" "^1.2.2"
-    "escope" "^3.6.0"
-    "espree" "^3.3.1"
-    "estraverse" "^4.2.0"
-    "esutils" "^2.0.2"
-    "file-entry-cache" "^2.0.0"
-    "glob" "^7.0.3"
-    "globals" "^9.2.0"
-    "ignore" "^3.1.5"
-    "imurmurhash" "^0.1.4"
-    "inquirer" "^0.12.0"
-    "is-my-json-valid" "^2.10.0"
-    "is-resolvable" "^1.0.0"
-    "js-yaml" "^3.5.1"
-    "json-stable-stringify" "^1.0.0"
-    "levn" "^0.3.0"
-    "lodash" "^4.0.0"
-    "mkdirp" "^0.5.0"
-    "natural-compare" "^1.4.0"
-    "optionator" "^0.8.2"
-    "path-is-inside" "^1.0.1"
-    "pluralize" "^1.2.1"
-    "progress" "^1.1.8"
-    "require-uncached" "^1.0.2"
-    "shelljs" "^0.6.0"
-    "strip-bom" "^3.0.0"
-    "strip-json-comments" "~1.0.1"
-    "table" "^3.7.8"
-    "text-table" "~0.2.0"
-    "user-home" "^2.0.0"
-
-"espree@^3.1.3", "espree@^3.1.6", "espree@^3.3.1":
-  "integrity" "sha1-QWVvpWKOBCh4Al70Z+ePEly4bh0="
-  "resolved" "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz"
-  "version" "3.4.0"
-  dependencies:
-    "acorn" "4.0.4"
-    "acorn-jsx" "^3.0.0"
-
-"esprima@^3.1.1":
-  "integrity" "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-  "resolved" "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
-  "version" "3.1.3"
-
-"espurify@^1.5.0":
-  "integrity" "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY="
-  "resolved" "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz"
-  "version" "1.7.0"
-  dependencies:
-    "core-js" "^2.0.0"
-
-"esrecurse@^4.1.0":
-  "integrity" "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA="
-  "resolved" "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz"
-  "version" "4.1.0"
-  dependencies:
-    "estraverse" "~4.1.0"
-    "object-assign" "^4.0.1"
-
-"estraverse@^4.1.1", "estraverse@^4.2.0":
-  "integrity" "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-  "resolved" "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-  "version" "4.2.0"
-
-"estraverse@~4.1.0":
-  "integrity" "sha1-9srKcokzqFDvkGYdDheYK6RxEaI="
-  "resolved" "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
-  "version" "4.1.1"
-
-"estree-walker@^0.2.1":
-  "integrity" "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
-  "resolved" "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz"
-  "version" "0.2.1"
-
-"estree-walker@^0.3.0":
-  "integrity" "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
-  "resolved" "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz"
-  "version" "0.3.1"
-
-"estree-walker@^0.5.2":
-  "integrity" "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
-  "resolved" "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz"
-  "version" "0.5.2"
-
-"esutils@^2.0.2":
-  "integrity" "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-  "resolved" "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-  "version" "2.0.2"
-
-"event-emitter@~0.3.5":
-  "integrity" "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk="
-  "resolved" "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-  "version" "0.3.5"
-  dependencies:
-    "d" "1"
-    "es5-ext" "~0.10.14"
-
-"eventemitter3@1.x.x":
-  "integrity" "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
-  "resolved" "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
-  "version" "1.2.0"
-
-"events@^1.1.1":
-  "integrity" "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-  "resolved" "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
-  "version" "1.1.1"
-
-"evp_bytestokey@^1.0.0":
-  "integrity" "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM="
-  "resolved" "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "create-hash" "^1.1.1"
-
-"exec-series@^1.0.0":
-  "integrity" "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo="
-  "resolved" "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz"
-  "version" "1.0.3"
-  dependencies:
-    "async-each-series" "^1.1.0"
-    "object-assign" "^4.1.0"
-
-"exit-hook@^1.0.0":
-  "integrity" "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-  "resolved" "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-  "version" "1.1.1"
-
-"expand-brackets@^0.1.4":
-  "integrity" "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
-  "resolved" "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
-  "version" "0.1.5"
-  dependencies:
-    "is-posix-bracket" "^0.1.0"
-
-"expand-brackets@^2.1.4":
-  "integrity" "sha1-t3c14xXOMPa27/D4OwQVGiJEliI="
-  "resolved" "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz"
-  "version" "2.1.4"
-  dependencies:
-    "debug" "^2.3.3"
-    "define-property" "^0.2.5"
-    "extend-shallow" "^2.0.1"
-    "posix-character-classes" "^0.1.0"
-    "regex-not" "^1.0.0"
-    "snapdragon" "^0.8.1"
-    "to-regex" "^3.0.1"
-
-"expand-range@^1.8.1":
-  "integrity" "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
-  "resolved" "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
-  "version" "1.8.2"
-  dependencies:
-    "fill-range" "^2.1.0"
-
-"expand-tilde@^1.2.2":
-  "integrity" "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk="
-  "resolved" "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
-  "version" "1.2.2"
-  dependencies:
-    "os-homedir" "^1.0.1"
-
-"expect.js@0.3.1":
-  "integrity" "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s="
-  "resolved" "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz"
-  "version" "0.3.1"
-
-"ext-list@^2.0.0":
-  "integrity" "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA=="
-  "resolved" "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz"
-  "version" "2.2.2"
-  dependencies:
-    "mime-db" "^1.28.0"
-
-"ext-name@^5.0.0":
-  "integrity" "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ=="
-  "resolved" "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz"
-  "version" "5.0.0"
-  dependencies:
-    "ext-list" "^2.0.0"
-    "sort-keys-length" "^1.0.0"
-
-"extend-shallow@^2.0.1":
-  "integrity" "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8="
-  "resolved" "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "is-extendable" "^0.1.0"
-
-"extend-shallow@^3.0.0":
-  "integrity" "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg="
-  "resolved" "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz"
-  "version" "3.0.2"
-  dependencies:
-    "assign-symbols" "^1.0.0"
-    "is-extendable" "^1.0.1"
-
-"extend-shallow@^3.0.2":
-  "integrity" "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg="
-  "resolved" "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz"
-  "version" "3.0.2"
-  dependencies:
-    "assign-symbols" "^1.0.0"
-    "is-extendable" "^1.0.1"
-
-"extend@^3.0.0":
-  "integrity" "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
-  "resolved" "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-  "version" "3.0.0"
-
-"extend@~3.0.0":
-  "integrity" "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-  "resolved" "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
-  "version" "3.0.2"
-
-"extglob@^0.3.1":
-  "integrity" "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
-  "resolved" "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-  "version" "0.3.2"
-  dependencies:
-    "is-extglob" "^1.0.0"
-
-"extglob@^2.0.4":
-  "integrity" "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw=="
-  "resolved" "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz"
-  "version" "2.0.4"
-  dependencies:
-    "array-unique" "^0.3.2"
-    "define-property" "^1.0.0"
-    "expand-brackets" "^2.1.4"
-    "extend-shallow" "^2.0.1"
-    "fragment-cache" "^0.2.1"
-    "regex-not" "^1.0.0"
-    "snapdragon" "^0.8.1"
-    "to-regex" "^3.0.1"
-
-"extsprintf@^1.2.0":
-  "integrity" "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
-  "resolved" "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz"
-  "version" "1.4.0"
-
-"extsprintf@1.3.0":
-  "integrity" "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-  "resolved" "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
-  "version" "1.3.0"
-
-"fancy-log@^1.1.0":
-  "integrity" "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg="
-  "resolved" "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz"
-  "version" "1.3.0"
-  dependencies:
-    "chalk" "^1.1.1"
-    "time-stamp" "^1.0.0"
-
-"fast-levenshtein@~2.0.4":
-  "integrity" "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-  "resolved" "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
-  "version" "2.0.6"
-
-"faye-websocket@~0.10.0":
-  "integrity" "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ="
-  "resolved" "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
-  "version" "0.10.0"
-  dependencies:
-    "websocket-driver" ">=0.5.1"
-
-"fd-slicer@~1.0.1":
-  "integrity" "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU="
-  "resolved" "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
-  "version" "1.0.1"
-  dependencies:
-    "pend" "~1.2.0"
-
-"feature-detect-es6@^1.3.1":
-  "integrity" "sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8="
-  "resolved" "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz"
-  "version" "1.3.1"
-  dependencies:
-    "array-back" "^1.0.3"
-
-"fetch-mock@5.12.2":
-  "integrity" "sha1-B/3mtx9xgyi0zpuByCp8EcBdl0g="
-  "resolved" "https://registry.npmjs.org/fetch-mock/-/fetch-mock-5.12.2.tgz"
-  "version" "5.12.2"
-  dependencies:
-    "glob-to-regexp" "^0.3.0"
-    "node-fetch" "^1.3.3"
-    "path-to-regexp" "^1.7.0"
-
-"figures@^1.3.5":
-  "integrity" "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
-  "resolved" "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
-  "version" "1.7.0"
-  dependencies:
-    "escape-string-regexp" "^1.0.5"
-    "object-assign" "^4.1.0"
-
-"file-entry-cache@^1.3.1":
-  "integrity" "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g="
-  "resolved" "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz"
-  "version" "1.3.1"
-  dependencies:
-    "flat-cache" "^1.2.1"
-    "object-assign" "^4.0.1"
-
-"file-entry-cache@^2.0.0":
-  "integrity" "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E="
-  "resolved" "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "flat-cache" "^1.2.1"
-    "object-assign" "^4.0.1"
-
-"file-set@^2.0.1":
-  "integrity" "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA=="
-  "resolved" "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "array-back" "^2.0.0"
-    "glob" "^7.1.3"
-
-"file-type@^3.1.0":
-  "integrity" "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-  "resolved" "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz"
-  "version" "3.9.0"
-
-"file-type@^3.8.0":
-  "integrity" "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-  "resolved" "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz"
-  "version" "3.9.0"
-
-"file-type@^5.2.0", "file-type@5.2.0":
-  "integrity" "sha1-LdvqfHP/42No365J3DOMBYwritY="
-  "resolved" "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz"
-  "version" "5.2.0"
-
-"file-type@^6.1.0":
-  "integrity" "sha1-Wn26mBOPoKvsevxD5amgsqrHKfE="
-  "resolved" "https://registry.npmjs.org/file-type/-/file-type-6.1.0.tgz"
-  "version" "6.1.0"
-
-"filename-regex@^2.0.0":
-  "integrity" "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-  "resolved" "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
-  "version" "2.0.1"
-
-"filename-reserved-regex@^1.0.0":
-  "integrity" "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
-  "resolved" "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
-  "version" "1.0.0"
-
-"filename-reserved-regex@^2.0.0":
-  "integrity" "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
-  "resolved" "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz"
-  "version" "2.0.0"
-
-"filenamify@^1.0.1":
-  "integrity" "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU="
-  "resolved" "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz"
-  "version" "1.2.1"
-  dependencies:
-    "filename-reserved-regex" "^1.0.0"
-    "strip-outer" "^1.0.0"
-    "trim-repeated" "^1.0.0"
-
-"filenamify@^2.0.0":
-  "integrity" "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU="
-  "resolved" "https://registry.npmjs.org/filenamify/-/filenamify-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "filename-reserved-regex" "^2.0.0"
-    "strip-outer" "^1.0.0"
-    "trim-repeated" "^1.0.0"
-
-"filesize@^3.5.10":
-  "integrity" "sha1-/I+iPdtO+eXgq24eZPZ5okpWdh8="
-  "resolved" "https://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz"
-  "version" "3.5.10"
-
-"fill-range@^2.1.0":
-  "integrity" "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q=="
-  "resolved" "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz"
-  "version" "2.2.4"
-  dependencies:
-    "is-number" "^2.1.0"
-    "isobject" "^2.0.0"
-    "randomatic" "^3.0.0"
-    "repeat-element" "^1.1.2"
-    "repeat-string" "^1.5.2"
-
-"fill-range@^4.0.0":
-  "integrity" "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc="
-  "resolved" "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "extend-shallow" "^2.0.1"
-    "is-number" "^3.0.0"
-    "repeat-string" "^1.6.1"
-    "to-regex-range" "^2.1.0"
-
-"find-replace@^3.0.0":
-  "integrity" "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ=="
-  "resolved" "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "array-back" "^3.0.1"
-
-"find-up@^1.0.0":
-  "integrity" "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
-  "resolved" "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-  "version" "1.1.2"
-  dependencies:
-    "path-exists" "^2.0.0"
-    "pinkie-promise" "^2.0.0"
-
-"first-chunk-stream@^1.0.0":
-  "integrity" "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
-  "resolved" "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-  "version" "1.0.0"
-
-"flat-cache@^1.2.1":
-  "integrity" "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y="
-  "resolved" "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz"
-  "version" "1.2.2"
-  dependencies:
-    "circular-json" "^0.3.1"
-    "del" "^2.0.2"
-    "graceful-fs" "^4.1.2"
-    "write" "^0.2.1"
-
-"for-in@^1.0.1", "for-in@^1.0.2":
-  "integrity" "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-  "resolved" "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-  "version" "1.0.2"
-
-"for-own@^0.1.4":
-  "integrity" "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
-  "resolved" "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz"
-  "version" "0.1.5"
-  dependencies:
-    "for-in" "^1.0.1"
-
-"foreach@^2.0.5", "foreach@~2.0.1":
-  "integrity" "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-  "resolved" "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-  "version" "2.0.5"
-
-"forever-agent@~0.5.0":
-  "integrity" "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
-  "resolved" "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-  "version" "0.5.2"
-
-"forever-agent@~0.6.1":
-  "integrity" "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-  "resolved" "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-  "version" "0.6.1"
-
-"form-data@~0.2.0":
-  "integrity" "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY="
-  "resolved" "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
-  "version" "0.2.0"
-  dependencies:
-    "async" "~0.9.0"
-    "combined-stream" "~0.0.4"
-    "mime-types" "~2.0.3"
-
-"form-data@~2.1.1":
-  "integrity" "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
-  "resolved" "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
-  "version" "2.1.4"
-  dependencies:
-    "asynckit" "^0.4.0"
-    "combined-stream" "^1.0.5"
-    "mime-types" "^2.1.12"
-
-"fragment-cache@^0.2.1":
-  "integrity" "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk="
-  "resolved" "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz"
-  "version" "0.2.1"
-  dependencies:
-    "map-cache" "^0.2.2"
-
-"fs-exists-sync@^0.1.0":
-  "integrity" "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
-  "resolved" "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
-  "version" "0.1.0"
-
-"fs-extra@1.0.0":
-  "integrity" "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA="
-  "resolved" "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "graceful-fs" "^4.1.2"
-    "jsonfile" "^2.1.0"
-    "klaw" "^1.0.0"
-
-"fs-readdir-recursive@^1.1.0":
-  "integrity" "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
-  "resolved" "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz"
-  "version" "1.1.0"
-
-"fs-then-native@^2.0.0":
-  "integrity" "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc="
-  "resolved" "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz"
-  "version" "2.0.0"
-
-"fs.realpath@^1.0.0":
-  "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-  "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-  "version" "1.0.0"
-
-"function-bind@^1.0.2", "function-bind@^1.1.1":
-  "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-  "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
-  "version" "1.1.1"
-
-"fwd-stream@^1.0.4":
-  "integrity" "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo="
-  "resolved" "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz"
-  "version" "1.0.4"
-  dependencies:
-    "readable-stream" "~1.0.26-4"
-
-"generate-function@^2.0.0":
-  "integrity" "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-  "resolved" "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-  "version" "2.0.0"
-
-"generate-object-property@^1.1.0":
-  "integrity" "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
-  "resolved" "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-  "version" "1.2.0"
-  dependencies:
-    "is-property" "^1.0.0"
-
-"gensync@^1.0.0-beta.2":
-  "integrity" "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
-  "resolved" "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
-  "version" "1.0.0-beta.2"
-
-"get-proxy@^1.0.1":
-  "integrity" "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus="
-  "resolved" "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz"
-  "version" "1.1.0"
-  dependencies:
-    "rc" "^1.1.2"
-
-"get-proxy@^2.0.0":
-  "integrity" "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw=="
-  "resolved" "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz"
-  "version" "2.1.0"
-  dependencies:
-    "npm-conf" "^1.1.0"
-
-"get-stdin@^4.0.1":
-  "integrity" "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-  "resolved" "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-  "version" "4.0.1"
-
-"get-stdin@5.0.1":
-  "integrity" "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
-  "resolved" "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
-  "version" "5.0.1"
-
-"get-stream@^2.2.0":
-  "integrity" "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4="
-  "resolved" "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz"
-  "version" "2.3.1"
-  dependencies:
-    "object-assign" "^4.0.1"
-    "pinkie-promise" "^2.0.0"
-
-"get-stream@^3.0.0":
-  "integrity" "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-  "resolved" "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
-  "version" "3.0.0"
-
-"get-value@^2.0.3", "get-value@^2.0.6":
-  "integrity" "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-  "resolved" "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
-  "version" "2.0.6"
-
-"getpass@^0.1.1":
-  "integrity" "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
-  "resolved" "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-  "version" "0.1.7"
-  dependencies:
-    "assert-plus" "^1.0.0"
-
-"glob-base@^0.3.0":
-  "integrity" "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q="
-  "resolved" "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-  "version" "0.3.0"
-  dependencies:
-    "glob-parent" "^2.0.0"
-    "is-glob" "^2.0.0"
-
-"glob-parent@^2.0.0":
-  "integrity" "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
-  "resolved" "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "is-glob" "^2.0.0"
-
-"glob-parent@^3.0.0":
-  "integrity" "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4="
-  "resolved" "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "is-glob" "^3.1.0"
-    "path-dirname" "^1.0.0"
-
-"glob-stream@^5.3.2":
-  "integrity" "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI="
-  "resolved" "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz"
-  "version" "5.3.5"
-  dependencies:
-    "extend" "^3.0.0"
-    "glob" "^5.0.3"
-    "glob-parent" "^3.0.0"
-    "micromatch" "^2.3.7"
-    "ordered-read-streams" "^0.3.0"
-    "through2" "^0.6.0"
-    "to-absolute-glob" "^0.1.1"
-    "unique-stream" "^2.0.2"
-
-"glob-to-regexp@^0.3.0":
-  "integrity" "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
-  "resolved" "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz"
-  "version" "0.3.0"
-
-"glob@^5.0.3":
-  "integrity" "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E="
-  "resolved" "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-  "version" "5.0.15"
-  dependencies:
-    "inflight" "^1.0.4"
-    "inherits" "2"
-    "minimatch" "2 || 3"
-    "once" "^1.3.0"
-    "path-is-absolute" "^1.0.0"
-
-"glob@^7.0.3":
-  "integrity" "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
-  "resolved" "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-  "version" "7.1.1"
-  dependencies:
-    "fs.realpath" "^1.0.0"
-    "inflight" "^1.0.4"
-    "inherits" "2"
-    "minimatch" "^3.0.2"
-    "once" "^1.3.0"
-    "path-is-absolute" "^1.0.0"
-
-"glob@^7.0.5":
-  "integrity" "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ=="
-  "resolved" "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
-  "version" "7.1.3"
-  dependencies:
-    "fs.realpath" "^1.0.0"
-    "inflight" "^1.0.4"
-    "inherits" "2"
-    "minimatch" "^3.0.4"
-    "once" "^1.3.0"
-    "path-is-absolute" "^1.0.0"
-
-"glob@^7.1.3":
-  "integrity" "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A=="
-  "resolved" "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
-  "version" "7.1.4"
-  dependencies:
-    "fs.realpath" "^1.0.0"
-    "inflight" "^1.0.4"
-    "inherits" "2"
-    "minimatch" "^3.0.4"
-    "once" "^1.3.0"
-    "path-is-absolute" "^1.0.0"
-
-"glob@7.1.1":
-  "integrity" "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
-  "resolved" "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-  "version" "7.1.1"
-  dependencies:
-    "fs.realpath" "^1.0.0"
-    "inflight" "^1.0.4"
-    "inherits" "2"
-    "minimatch" "^3.0.2"
-    "once" "^1.3.0"
-    "path-is-absolute" "^1.0.0"
-
-"glob@7.1.2":
-  "integrity" "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
-  "resolved" "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-  "version" "7.1.2"
-  dependencies:
-    "fs.realpath" "^1.0.0"
-    "inflight" "^1.0.4"
-    "inherits" "2"
-    "minimatch" "^3.0.4"
-    "once" "^1.3.0"
-    "path-is-absolute" "^1.0.0"
-
-"global-modules@^0.2.3":
-  "integrity" "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0="
-  "resolved" "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
-  "version" "0.2.3"
-  dependencies:
-    "global-prefix" "^0.1.4"
-    "is-windows" "^0.2.0"
-
-"global-prefix@^0.1.4":
-  "integrity" "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948="
-  "resolved" "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz"
-  "version" "0.1.5"
-  dependencies:
-    "homedir-polyfill" "^1.0.0"
-    "ini" "^1.3.4"
-    "is-windows" "^0.2.0"
-    "which" "^1.2.12"
-
-"globals@^11.1.0":
-  "integrity" "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-  "resolved" "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
-  "version" "11.12.0"
-
-"globals@^9.0.0", "globals@^9.2.0":
-  "integrity" "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY="
-  "resolved" "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
-  "version" "9.17.0"
-
-"globals@^9.18.0":
-  "integrity" "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-  "resolved" "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-  "version" "9.18.0"
-
-"globby@^5.0.0":
-  "integrity" "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0="
-  "resolved" "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz"
-  "version" "5.0.0"
-  dependencies:
-    "array-union" "^1.0.1"
-    "arrify" "^1.0.0"
-    "glob" "^7.0.3"
-    "object-assign" "^4.0.1"
-    "pify" "^2.0.0"
-    "pinkie-promise" "^2.0.0"
-
-"glogg@^1.0.0":
-  "integrity" "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U="
-  "resolved" "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "sparkles" "^1.0.0"
-
-"got@^5.0.0":
-  "integrity" "sha1-X4FjWmHkplifGAVp6k44FoClHzU="
-  "resolved" "https://registry.npmjs.org/got/-/got-5.7.1.tgz"
-  "version" "5.7.1"
-  dependencies:
-    "create-error-class" "^3.0.1"
-    "duplexer2" "^0.1.4"
-    "is-redirect" "^1.0.0"
-    "is-retry-allowed" "^1.0.0"
-    "is-stream" "^1.0.0"
-    "lowercase-keys" "^1.0.0"
-    "node-status-codes" "^1.0.0"
-    "object-assign" "^4.0.1"
-    "parse-json" "^2.1.0"
-    "pinkie-promise" "^2.0.0"
-    "read-all-stream" "^3.0.0"
-    "readable-stream" "^2.0.5"
-    "timed-out" "^3.0.0"
-    "unzip-response" "^1.0.2"
-    "url-parse-lax" "^1.0.0"
-
-"got@^7.0.0":
-  "integrity" "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw=="
-  "resolved" "https://registry.npmjs.org/got/-/got-7.1.0.tgz"
-  "version" "7.1.0"
-  dependencies:
-    "decompress-response" "^3.2.0"
-    "duplexer3" "^0.1.4"
-    "get-stream" "^3.0.0"
-    "is-plain-obj" "^1.1.0"
-    "is-retry-allowed" "^1.0.0"
-    "is-stream" "^1.0.0"
-    "isurl" "^1.0.0-alpha5"
-    "lowercase-keys" "^1.0.0"
-    "p-cancelable" "^0.3.0"
-    "p-timeout" "^1.1.1"
-    "safe-buffer" "^5.0.1"
-    "timed-out" "^4.0.0"
-    "url-parse-lax" "^1.0.0"
-    "url-to-options" "^1.0.1"
-
-"graceful-fs@^4.0.0", "graceful-fs@^4.1.10", "graceful-fs@^4.1.6", "graceful-fs@^4.1.9":
-  "integrity" "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-  "resolved" "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-  "version" "4.1.11"
-
-"graceful-fs@^4.1.11":
-  "integrity" "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-  "resolved" "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz"
-  "version" "4.1.15"
-
-"graceful-fs@^4.1.2":
-  "integrity" "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-  "resolved" "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz"
-  "version" "4.1.15"
+    fsevents "^1.0.0"
+
+cipher-base@^1.0.0, cipher-base@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
+  integrity sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=
+  dependencies:
+    inherits "^2.0.1"
+
+circular-json@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
+  integrity sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz"
+  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
+
+cli-cursor@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
+  integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-width@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
+  integrity sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=
+
+clone-stats@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+  integrity sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=
+
+clone@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+  integrity sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=
+
+clone@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+  integrity sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=
+
+clone@~0.1.9:
+  version "0.1.19"
+  resolved "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+  integrity sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=
+
+co@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+  integrity sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collect-all@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz"
+  integrity sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==
+  dependencies:
+    stream-connect "^1.0.2"
+    stream-via "^1.0.4"
+
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz"
+  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+colorette@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz"
+  integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
+
+colors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+
+combined-stream@^1.0.5, combined-stream@~1.0.5:
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@~0.0.4, combined-stream@~0.0.5:
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
+  integrity sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=
+  dependencies:
+    delayed-stream "0.0.5"
+
+command-line-args@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz"
+  integrity sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==
+  dependencies:
+    array-back "^3.0.1"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-tool@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz"
+  integrity sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==
+  dependencies:
+    ansi-escape-sequences "^4.0.0"
+    array-back "^2.0.0"
+    command-line-args "^5.0.0"
+    command-line-usage "^4.1.0"
+    typical "^2.6.1"
+
+command-line-usage@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.0.0.tgz"
+  integrity sha1-gWsyeItY+f66RNHm2sYPyuspteo=
+  dependencies:
+    ansi-escape-sequences "^3.0.0"
+    array-back "^1.0.4"
+    table-layout "^0.4.0"
+    typical "^2.6.0"
+
+command-line-usage@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz"
+  integrity sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==
+  dependencies:
+    ansi-escape-sequences "^4.0.0"
+    array-back "^2.0.0"
+    table-layout "^0.4.2"
+    typical "^2.6.1"
+
+commander@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+  integrity sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=
+
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
+commander@~2.8.1:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
+  integrity sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
+common-sequence@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz"
+  integrity sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=
+
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+concat-stream@^1.4.4, concat-stream@^1.4.6, concat-stream@^1.4.7:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz"
+  integrity sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concurrently@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz"
+  integrity sha1-jPG3cHppFqeKT/W3e7BN7FSzebI=
+  dependencies:
+    chalk "0.5.1"
+    commander "2.6.0"
+    date-fns "^1.23.0"
+    lodash "^4.5.1"
+    rx "2.3.24"
+    spawn-command "^0.0.2-1"
+    supports-color "^3.2.3"
+    tree-kill "^1.1.0"
+
+config-chain@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz"
+  integrity sha1-q6CXR9++TD5w52am5BWG4YWfxvI=
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
+
+config-master@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz"
+  integrity sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=
+  dependencies:
+    walk-back "^2.0.1"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
+content-disposition@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+  integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
+
+continuable-cache@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz"
+  integrity sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=
+
+convert-source-map@^1.1.1, convert-source-map@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+  integrity sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=
+
+convert-source-map@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz"
+  integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
+  dependencies:
+    safe-buffer "~5.1.1"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
+  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+core-assert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz"
+  integrity sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=
+  dependencies:
+    buf-compare "^1.0.0"
+    is-error "^2.2.0"
+
+core-js@^2.0.0, core-js@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+  integrity sha1-TekR5mew6ukSTjQlS1OupvxhjT4=
+
+core-js@^2.4.1, core-js@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz"
+  integrity sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=
+
+core-util-is@1.0.2, core-util-is@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+corser@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz"
+  integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
+
+create-ecdh@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
+  integrity sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=
+  dependencies:
+    bn.js "^4.1.0"
+    elliptic "^6.0.0"
+
+create-error-class@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
+  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
+create-hash@^1.1.0, create-hash@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
+  integrity sha1-USEAYte7dHn2xlu0GpIgix1hq60=
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    ripemd160 "^1.0.0"
+    sha.js "^2.3.6"
+
+create-hmac@^1.1.0, create-hmac@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+  integrity sha1-0/tLolPriz9W456i+8uK90e9MXA=
+  dependencies:
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+
+cryptiles@0.2.x:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+  integrity sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=
+  dependencies:
+    boom "0.4.x"
+
+cryptiles@2.x.x:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+  integrity sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=
+  dependencies:
+    boom "2.x.x"
+
+crypto-browserify@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
+  integrity sha1-zFRJaF37hesRyYKKzHy4erW7/MA=
+
+crypto-browserify@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
+  integrity sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=
+  dependencies:
+    browserify-cipher "^1.0.0"
+    browserify-sign "^4.0.0"
+    create-ecdh "^4.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.0"
+    diffie-hellman "^5.0.0"
+    inherits "^2.0.1"
+    pbkdf2 "^3.0.3"
+    public-encrypt "^4.0.0"
+    randombytes "^2.0.0"
+
+ctype@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+  integrity sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=
+
+d@1:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
+  integrity sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
+  dependencies:
+    es5-ext "^0.10.9"
+
+damerau-levenshtein@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz"
+  integrity sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=
+
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
+  dependencies:
+    assert-plus "^1.0.0"
+
+date-fns@^1.23.0:
+  version "1.28.5"
+  resolved "https://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz"
+  integrity sha1-JXz8RdMi30XvVlhmWWfuhBzXP68=
+
+dateformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz"
+  integrity sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=
+
+debug@2.6.8, debug@^2.6.8, debug@~2.6.7:
+  version "2.6.8"
+  resolved "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+  integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.1.1:
+  version "2.6.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz"
+  integrity sha1-D364wwll7AjHKsz6ATDIt5mEFB0=
+  dependencies:
+    ms "0.7.2"
+
+debug@^2.2.0, debug@^2.3.3:
+  version "2.6.9"
+  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@^4.1.0:
+  version "4.3.2"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+decompress-response@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz"
+  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
+  dependencies:
+    mimic-response "^1.0.0"
+
+decompress-tar@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz"
+  integrity sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=
+  dependencies:
+    is-tar "^1.0.0"
+    object-assign "^2.0.0"
+    strip-dirs "^1.0.0"
+    tar-stream "^1.1.1"
+    through2 "^0.6.1"
+    vinyl "^0.4.3"
+
+decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz"
+  integrity sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==
+  dependencies:
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+    tar-stream "^1.5.2"
+
+decompress-tarbz2@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz"
+  integrity sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=
+  dependencies:
+    is-bzip2 "^1.0.0"
+    object-assign "^2.0.0"
+    seek-bzip "^1.0.3"
+    strip-dirs "^1.0.0"
+    tar-stream "^1.1.1"
+    through2 "^0.6.1"
+    vinyl "^0.4.3"
+
+decompress-tarbz2@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz"
+  integrity sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==
+  dependencies:
+    decompress-tar "^4.1.0"
+    file-type "^6.1.0"
+    is-stream "^1.1.0"
+    seek-bzip "^1.0.5"
+    unbzip2-stream "^1.0.9"
+
+decompress-targz@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz"
+  integrity sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=
+  dependencies:
+    is-gzip "^1.0.0"
+    object-assign "^2.0.0"
+    strip-dirs "^1.0.0"
+    tar-stream "^1.1.1"
+    through2 "^0.6.1"
+    vinyl "^0.4.3"
+
+decompress-targz@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz"
+  integrity sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==
+  dependencies:
+    decompress-tar "^4.1.1"
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+
+decompress-unzip@^3.0.0:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz"
+  integrity sha1-YUdbQVIGa74/7hL51inRX+ZHjus=
+  dependencies:
+    is-zip "^1.0.0"
+    read-all-stream "^3.0.0"
+    stat-mode "^0.2.0"
+    strip-dirs "^1.0.0"
+    through2 "^2.0.0"
+    vinyl "^1.0.0"
+    yauzl "^2.2.1"
+
+decompress-unzip@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz"
+  integrity sha1-3qrM39FK6vhVePczroIQ+bSEj2k=
+  dependencies:
+    file-type "^3.8.0"
+    get-stream "^2.2.0"
+    pify "^2.3.0"
+    yauzl "^2.4.2"
+
+decompress@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz"
+  integrity sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=
+  dependencies:
+    buffer-to-vinyl "^1.0.0"
+    concat-stream "^1.4.6"
+    decompress-tar "^3.0.0"
+    decompress-tarbz2 "^3.0.0"
+    decompress-targz "^3.0.0"
+    decompress-unzip "^3.0.0"
+    stream-combiner2 "^1.1.1"
+    vinyl-assign "^1.0.1"
+    vinyl-fs "^2.2.0"
+
+decompress@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz"
+  integrity sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=
+  dependencies:
+    decompress-tar "^4.0.0"
+    decompress-tarbz2 "^4.0.0"
+    decompress-targz "^4.0.0"
+    decompress-unzip "^4.0.1"
+    graceful-fs "^4.1.10"
+    make-dir "^1.0.0"
+    pify "^2.3.0"
+    strip-dirs "^2.0.0"
+
+deep-extend@~0.4.0:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+  integrity sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=
+
+deep-extend@~0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+  integrity sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=
+
+deep-extend@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deep-strict-equal@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz"
+  integrity sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=
+  dependencies:
+    core-assert "^0.2.0"
+
+deferred-leveldown@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz"
+  integrity sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=
+  dependencies:
+    abstract-leveldown "~0.12.1"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz"
+  integrity sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz"
+  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz"
+  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
+
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
+  integrity sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
+
+delayed-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+  integrity sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+des.js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
+  integrity sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=
+  dependencies:
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
+detect-indent@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
+  integrity sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=
+  dependencies:
+    get-stdin "^4.0.1"
+    minimist "^1.1.0"
+    repeating "^1.1.0"
+
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
+  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
+  dependencies:
+    repeating "^2.0.0"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
+  integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
+
+diffie-hellman@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
+  integrity sha1-tYNXOScM/ias9jIJn97SoH8gnl4=
+  dependencies:
+    bn.js "^4.1.0"
+    miller-rabin "^4.0.0"
+    randombytes "^2.0.0"
+
+dmd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/dmd/-/dmd-4.0.3.tgz"
+  integrity sha512-qU9jcZQCxfLlTbZU1e5jROXVkTsn9q3s1FmnOPFWo9tfDol3cSt0AZREiXCsgmSaS5L/AXXQqcZiR7YjFNAL1g==
+  dependencies:
+    array-back "^4.0.0"
+    cache-point "^0.4.1"
+    common-sequence "^1.0.2"
+    file-set "^2.0.1"
+    handlebars "^4.2.0"
+    marked "^0.7.0"
+    object-get "^2.1.0"
+    reduce-flatten "^2.0.0"
+    reduce-unique "^2.0.1"
+    reduce-without "^1.0.1"
+    test-value "^3.0.0"
+    walk-back "^3.0.1"
+
+doctrine@1.2.x:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-1.2.3.tgz"
+  integrity sha1-auxrvWLPid1JjK5wwO2fSdqHOmo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^1.2.2:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+download@^4.1.2:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/download/-/download-4.4.3.tgz"
+  integrity sha1-qlX9rTktldS2jowr4D4MKqIbqaw=
+  dependencies:
+    caw "^1.0.1"
+    concat-stream "^1.4.7"
+    each-async "^1.0.0"
+    filenamify "^1.0.1"
+    got "^5.0.0"
+    gulp-decompress "^1.2.0"
+    gulp-rename "^1.2.0"
+    is-url "^1.2.0"
+    object-assign "^4.0.1"
+    read-all-stream "^3.0.0"
+    readable-stream "^2.0.2"
+    stream-combiner2 "^1.1.1"
+    vinyl "^1.0.0"
+    vinyl-fs "^2.2.0"
+    ware "^1.2.0"
+
+download@^6.0.0:
+  version "6.2.5"
+  resolved "https://registry.npmjs.org/download/-/download-6.2.5.tgz"
+  integrity sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==
+  dependencies:
+    caw "^2.0.0"
+    content-disposition "^0.5.2"
+    decompress "^4.0.0"
+    ext-name "^5.0.0"
+    file-type "5.2.0"
+    filenamify "^2.0.0"
+    get-stream "^3.0.0"
+    got "^7.0.0"
+    make-dir "^1.0.0"
+    p-event "^1.0.0"
+    pify "^3.0.0"
+
+duplexer2@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+  integrity sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=
+  dependencies:
+    readable-stream "~1.1.9"
+
+duplexer2@^0.1.4, duplexer2@~0.1.0:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
+  dependencies:
+    readable-stream "^2.0.2"
+
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz"
+  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
+
+duplexify@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz"
+  integrity sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=
+  dependencies:
+    end-of-stream "1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
+each-async@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz"
+  integrity sha1-3uUim98KtrogEqOV4bhpq/iBNHM=
+  dependencies:
+    onetime "^1.0.0"
+    set-immediate-shim "^1.0.0"
+
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
+  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
+ecstatic@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz"
+  integrity sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==
+  dependencies:
+    he "^1.1.1"
+    mime "^1.2.11"
+    minimist "^1.1.0"
+    url-join "^2.0.2"
+
+electron-to-chromium@^1.3.18:
+  version "1.3.21"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz"
+  integrity sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI=
+
+electron-to-chromium@^1.3.811:
+  version "1.3.823"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.823.tgz"
+  integrity sha512-jbwqBmqo9ZBWNfz6EKDTx66rqRDt87ZbOxtUegYNpkVMX6z93PMaFbDy7/LIPRwMI/5T4GVcYkROWDPQm9Ni7A==
+
+elliptic@^6.0.0:
+  version "6.4.0"
+  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+  integrity sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
+end-of-stream@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
+  integrity sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=
+  dependencies:
+    once "~1.3.0"
+
+end-of-stream@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz"
+  integrity sha1-epDYM+/abPpurA9JSduw+tOmMgY=
+  dependencies:
+    once "^1.4.0"
+
+enhance-visitors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz"
+  integrity sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=
+  dependencies:
+    lodash "^4.13.1"
+
+entities@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+errno@^0.1.1, errno@~0.1.1:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+  integrity sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=
+  dependencies:
+    prr "~0.0.0"
+
+error-ex@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+  integrity sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=
+  dependencies:
+    is-arrayish "^0.2.1"
+
+error@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/error/-/error-7.0.2.tgz"
+  integrity sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=
+  dependencies:
+    string-template "~0.2.1"
+    xtend "~4.0.0"
+
+es-abstract@^1.5.1:
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz"
+  integrity sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
+  integrity sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.15"
+  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+  integrity sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=
+  dependencies:
+    es6-iterator "2"
+    es6-symbol "~3.1"
+
+es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+  integrity sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
+
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz"
+  integrity sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
+es6-set@^0.1.4, es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
+  integrity sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+  integrity sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz"
+  integrity sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
+  integrity sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-import-resolver-node@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz"
+  integrity sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=
+  dependencies:
+    debug "^2.2.0"
+    object-assign "^4.0.1"
+    resolve "^1.1.6"
+
+eslint-plugin-ava@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-3.0.0.tgz"
+  integrity sha1-3bX8coDXlmOqz3K/d5h+GNVOV+k=
+  dependencies:
+    arrify "^1.0.1"
+    deep-strict-equal "^0.2.0"
+    enhance-visitors "^1.0.0"
+    espree "^3.1.3"
+    espurify "^1.5.0"
+    multimatch "^2.1.0"
+    pkg-up "^1.0.0"
+    req-all "^0.1.0"
+
+eslint-plugin-babel@3.3.x:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz"
+  integrity sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=
+
+eslint-plugin-chai-expect@1.1.x:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-1.1.1.tgz"
+  integrity sha1-zWQLizjPbDq8w3hnO3sXO5ndxwo=
+
+eslint-plugin-flowtype@2.7.x:
+  version "2.7.2"
+  resolved "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.7.2.tgz"
+  integrity sha1-rNCEH9LFX4a2n1TOkyNNC9h4lKk=
+  dependencies:
+    lodash "^4.9.0"
+
+eslint-plugin-import@1.13.x:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-1.13.0.tgz"
+  integrity sha1-DonthoOW0JEi4wft9ts3iBz93dc=
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.2.0"
+    doctrine "1.2.x"
+    es6-map "^0.1.3"
+    es6-set "^0.1.4"
+    eslint-import-resolver-node "^0.2.0"
+    lodash.cond "^4.3.0"
+    lodash.endswith "^4.0.1"
+    lodash.find "^4.3.0"
+    lodash.findindex "^4.3.0"
+    object-assign "^4.0.1"
+    pkg-dir "^1.0.0"
+    pkg-up "^1.0.0"
+
+eslint-plugin-jsx-a11y@2.1.x:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.1.0.tgz"
+  integrity sha1-dZUkuNcWHYSad6kXNaOXTdHPwys=
+  dependencies:
+    damerau-levenshtein "^1.0.0"
+    jsx-ast-utils "^1.0.0"
+    object-assign "^4.0.1"
+
+eslint-plugin-lodash@1.10.x:
+  version "1.10.3"
+  resolved "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-1.10.3.tgz"
+  integrity sha1-o0HjOGtutOS3rdz0PDp/lE84VR0=
+  dependencies:
+    lodash "^4.9.0"
+
+eslint-plugin-mocha@4.3.x:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.3.0.tgz"
+  integrity sha1-hAdblvw3/pZ9KbhgIoU6FP8lLMM=
+  dependencies:
+    ramda "^0.21.0"
+
+eslint-plugin-node@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-2.0.0.tgz"
+  integrity sha1-1J3EJ87cDfQ2I4zcsGrNlh+jjeU=
+  dependencies:
+    ignore "^3.0.11"
+    minimatch "^3.0.2"
+    object-assign "^4.0.1"
+    resolve "^1.1.7"
+    semver "5.2.0"
+
+eslint-plugin-promise@2.0.x:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-2.0.1.tgz"
+  integrity sha1-qXWc76XjirEbsu9loE7wQjCaoKQ=
+
+eslint-plugin-react@6.1.x:
+  version "6.1.2"
+  resolved "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.1.2.tgz"
+  integrity sha1-1gIr2bzkSOUXoAOrxkCefKGADGg=
+  dependencies:
+    doctrine "^1.2.2"
+    jsx-ast-utils "^1.3.1"
+
+eslint-plugin-shopify@14.0.0:
+  version "14.0.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-shopify/-/eslint-plugin-shopify-14.0.0.tgz"
+  integrity sha1-SqbKhyN3xynlEKZwSpGA8O06D28=
+  dependencies:
+    babel-eslint "6.1.x"
+    eslint-plugin-ava "3.0.x"
+    eslint-plugin-babel "3.3.x"
+    eslint-plugin-chai-expect "1.1.x"
+    eslint-plugin-flowtype "2.7.x"
+    eslint-plugin-import "1.13.x"
+    eslint-plugin-jsx-a11y "2.1.x"
+    eslint-plugin-lodash "1.10.x"
+    eslint-plugin-mocha "4.3.x"
+    eslint-plugin-node "2.0.x"
+    eslint-plugin-promise "2.0.x"
+    eslint-plugin-react "6.1.x"
+    eslint-plugin-sort-class-members "1.0.x"
+    merge "1.x"
+
+eslint-plugin-sort-class-members@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.0.2.tgz"
+  integrity sha1-svdMR9WklAxUHrVzxbwq4ct3hhA=
+
+eslint-test-generator@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/eslint-test-generator/-/eslint-test-generator-1.0.5.tgz"
+  integrity sha1-+KKigOj/+9LVUOU9aAeXctrv+OM=
+  dependencies:
+    eslint "3.3.x"
+    glob "^7.0.5"
+    handlebars "^4.0.5"
+    js-string-escape "^1.0.1"
+
+eslint@3.3.x:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.3.1.tgz#ed4ba34be175e2286c90a42ff636bf5e26d50968"
+  integrity sha512-/9SjGP30BzhOmYo1dtuoFYIyAL25jq8xNlXvL2w6UYWbrn0ca+daecGwS5ORhQ4qz8MTJKR2gM5KeLUiIlMzIQ==
+  dependencies:
+    chalk "^1.1.3"
+    concat-stream "^1.4.6"
+    debug "^2.1.1"
+    doctrine "^1.2.2"
+    escope "^3.6.0"
+    espree "^3.1.6"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^1.3.1"
+    glob "^7.0.3"
+    globals "^9.2.0"
+    ignore "^3.1.2"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.1"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.6.0"
+    strip-bom "^3.0.0"
+    strip-json-comments "~1.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
+eslint@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-3.8.1.tgz"
+  integrity sha1-fQLbRM1ar0+nqkieHwg7qkVDQro=
+  dependencies:
+    chalk "^1.1.3"
+    concat-stream "^1.4.6"
+    debug "^2.1.1"
+    doctrine "^1.2.2"
+    escope "^3.6.0"
+    espree "^3.3.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.2.0"
+    ignore "^3.1.5"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.6.0"
+    strip-bom "^3.0.0"
+    strip-json-comments "~1.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
+espree@^3.1.3, espree@^3.1.6, espree@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz"
+  integrity sha1-QWVvpWKOBCh4Al70Z+ePEly4bh0=
+  dependencies:
+    acorn "4.0.4"
+    acorn-jsx "^3.0.0"
+
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
+
+espurify@^1.5.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz"
+  integrity sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=
+  dependencies:
+    core-js "^2.0.0"
+
+esrecurse@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz"
+  integrity sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=
+  dependencies:
+    estraverse "~4.1.0"
+    object-assign "^4.0.1"
+
+estraverse@^4.1.1, estraverse@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+estraverse@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+  integrity sha1-9srKcokzqFDvkGYdDheYK6RxEaI=
+
+estree-walker@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz"
+  integrity sha1-va/oCVOD2EFNXcLs9MkXO225QS4=
+
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz"
+  integrity sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=
+
+estree-walker@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz"
+  integrity sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==
+
+esutils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+eventemitter3@1.x.x:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+  integrity sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
+
+events@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
+evp_bytestokey@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+  integrity sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=
+  dependencies:
+    create-hash "^1.1.1"
+
+exec-series@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz"
+  integrity sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=
+  dependencies:
+    async-each-series "^1.1.0"
+    object-assign "^4.1.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+  integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
+
+expand-brackets@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+  integrity sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=
+  dependencies:
+    is-posix-bracket "^0.1.0"
+
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz"
+  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+expand-range@^1.8.1:
+  version "1.8.2"
+  resolved "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
+  integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
+  dependencies:
+    fill-range "^2.1.0"
+
+expand-tilde@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
+  integrity sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=
+  dependencies:
+    os-homedir "^1.0.1"
+
+expect.js@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz"
+  integrity sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=
+
+ext-list@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz"
+  integrity sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==
+  dependencies:
+    mime-db "^1.28.0"
+
+ext-name@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz"
+  integrity sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==
+  dependencies:
+    ext-list "^2.0.0"
+    sort-keys-length "^1.0.0"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz"
+  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
+extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+  integrity sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=
+
+extend@~3.0.0:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+extglob@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+  integrity sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=
+  dependencies:
+    is-extglob "^1.0.0"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz"
+  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz"
+  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+fancy-log@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz"
+  integrity sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=
+  dependencies:
+    chalk "^1.1.1"
+    time-stamp "^1.0.0"
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+faye-websocket@~0.10.0:
+  version "0.10.0"
+  resolved "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
+  integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
+  dependencies:
+    websocket-driver ">=0.5.1"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+  integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
+  dependencies:
+    pend "~1.2.0"
+
+feature-detect-es6@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz"
+  integrity sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8=
+  dependencies:
+    array-back "^1.0.3"
+
+fetch-mock@5.12.2:
+  version "5.12.2"
+  resolved "https://registry.npmjs.org/fetch-mock/-/fetch-mock-5.12.2.tgz"
+  integrity sha1-B/3mtx9xgyi0zpuByCp8EcBdl0g=
+  dependencies:
+    glob-to-regexp "^0.3.0"
+    node-fetch "^1.3.3"
+    path-to-regexp "^1.7.0"
+
+figures@^1.3.5:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
+file-entry-cache@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz"
+  integrity sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz"
+  integrity sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
+file-set@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz"
+  integrity sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==
+  dependencies:
+    array-back "^2.0.0"
+    glob "^7.1.3"
+
+file-type@5.2.0, file-type@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz"
+  integrity sha1-LdvqfHP/42No365J3DOMBYwritY=
+
+file-type@^3.1.0, file-type@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz"
+  integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
+
+file-type@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/file-type/-/file-type-6.1.0.tgz"
+  integrity sha1-Wn26mBOPoKvsevxD5amgsqrHKfE=
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
+filename-regex@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+  integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
+
+filename-reserved-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+  integrity sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=
+
+filename-reserved-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz"
+  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify@^1.0.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz"
+  integrity sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=
+  dependencies:
+    filename-reserved-regex "^1.0.0"
+    strip-outer "^1.0.0"
+    trim-repeated "^1.0.0"
+
+filenamify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/filenamify/-/filenamify-2.0.0.tgz"
+  integrity sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.0"
+    trim-repeated "^1.0.0"
+
+filesize@^3.5.10:
+  version "3.5.10"
+  resolved "https://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz"
+  integrity sha1-/I+iPdtO+eXgq24eZPZ5okpWdh8=
+
+fill-range@^2.1.0:
+  version "2.2.4"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz"
+  integrity sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==
+  dependencies:
+    is-number "^2.1.0"
+    isobject "^2.0.0"
+    randomatic "^3.0.0"
+    repeat-element "^1.1.2"
+    repeat-string "^1.5.2"
+
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+  integrity sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+first-chunk-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+  integrity sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=
+
+flat-cache@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz"
+  integrity sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
+
+for-in@^1.0.1, for-in@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+for-own@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz"
+  integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
+  dependencies:
+    for-in "^1.0.1"
+
+foreach@^2.0.5, foreach@~2.0.1:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
+forever-agent@~0.5.0:
+  version "0.5.2"
+  resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+  integrity sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=
+
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+  integrity sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=
+  dependencies:
+    async "~0.9.0"
+    combined-stream "~0.0.4"
+    mime-types "~2.0.3"
+
+form-data@~2.1.1:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+  integrity sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz"
+  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
+  dependencies:
+    map-cache "^0.2.2"
+
+fs-exists-sync@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
+  integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
+
+fs-extra@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz"
+  integrity sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+
+fs-readdir-recursive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz"
+  integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
+
+fs-then-native@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz"
+  integrity sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fsevents@^1.0.0:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
+  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.12.1"
+
+function-bind@^1.0.2, function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+fwd-stream@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz"
+  integrity sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo=
+  dependencies:
+    readable-stream "~1.0.26-4"
+
+generate-function@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+  integrity sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=
+
+generate-object-property@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
+  dependencies:
+    is-property "^1.0.0"
+
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-proxy@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz"
+  integrity sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=
+  dependencies:
+    rc "^1.1.2"
+
+get-proxy@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz"
+  integrity sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==
+  dependencies:
+    npm-conf "^1.1.0"
+
+get-stdin@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
+  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+
+get-stdin@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+  integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz"
+  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
+  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+  dependencies:
+    assert-plus "^1.0.0"
+
+glob-base@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+  integrity sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=
+  dependencies:
+    glob-parent "^2.0.0"
+    is-glob "^2.0.0"
+
+glob-parent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
+  dependencies:
+    is-glob "^2.0.0"
+
+glob-parent@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz"
+  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
+glob-stream@^5.3.2:
+  version "5.3.5"
+  resolved "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz"
+  integrity sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=
+  dependencies:
+    extend "^3.0.0"
+    glob "^5.0.3"
+    glob-parent "^3.0.0"
+    micromatch "^2.3.7"
+    ordered-read-streams "^0.3.0"
+    through2 "^0.6.0"
+    to-absolute-glob "^0.1.1"
+    unique-stream "^2.0.2"
+
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz"
+  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob@7.1.1, glob@^7.0.3:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^5.0.3:
+  version "5.0.15"
+  resolved "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.5:
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+global-modules@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+  integrity sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=
+  dependencies:
+    global-prefix "^0.1.4"
+    is-windows "^0.2.0"
+
+global-prefix@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz"
+  integrity sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=
+  dependencies:
+    homedir-polyfill "^1.0.0"
+    ini "^1.3.4"
+    is-windows "^0.2.0"
+    which "^1.2.12"
+
+globals@^11.1.0:
+  version "11.12.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^9.0.0, globals@^9.2.0:
+  version "9.17.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
+  integrity sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=
+
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz"
+  integrity sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+glogg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+  integrity sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=
+  dependencies:
+    sparkles "^1.0.0"
+
+got@^5.0.0:
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/got/-/got-5.7.1.tgz"
+  integrity sha1-X4FjWmHkplifGAVp6k44FoClHzU=
+  dependencies:
+    create-error-class "^3.0.1"
+    duplexer2 "^0.1.4"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    node-status-codes "^1.0.0"
+    object-assign "^4.0.1"
+    parse-json "^2.1.0"
+    pinkie-promise "^2.0.0"
+    read-all-stream "^3.0.0"
+    readable-stream "^2.0.5"
+    timed-out "^3.0.0"
+    unzip-response "^1.0.2"
+    url-parse-lax "^1.0.0"
+
+got@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/got/-/got-7.1.0.tgz"
+  integrity sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==
+  dependencies:
+    decompress-response "^3.2.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-plain-obj "^1.1.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    p-cancelable "^0.3.0"
+    p-timeout "^1.1.1"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    url-parse-lax "^1.0.0"
+    url-to-options "^1.0.1"
+
+graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+  version "4.1.11"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+  integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+  version "4.1.15"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 "graceful-readlink@>= 1.0.0":
-  "integrity" "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-  "resolved" "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-  "version" "1.0.1"
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
-"graphql-js-client-compiler@0.2.0":
-  "integrity" "sha512-xqygOT7dygoka9QeFX1Khvgtp5Hjt9NW51lwYGR7b9J9qP2Ej5RQj39M8DRSZccU+zvWSiUR8wcY97HDyKeNQg=="
-  "resolved" "https://registry.npmjs.org/graphql-js-client-compiler/-/graphql-js-client-compiler-0.2.0.tgz"
-  "version" "0.2.0"
+graphql-js-client-compiler@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/graphql-js-client-compiler/-/graphql-js-client-compiler-0.2.0.tgz"
+  integrity sha512-xqygOT7dygoka9QeFX1Khvgtp5Hjt9NW51lwYGR7b9J9qP2Ej5RQj39M8DRSZccU+zvWSiUR8wcY97HDyKeNQg==
   dependencies:
-    "babel-generator" "6.25.0"
-    "babel-types" "6.25.0"
-    "command-line-usage" "4.0.0"
-    "graphql" "0.10.3"
-    "graphql-js-client" "0.7.0"
-    "graphql-js-schema" "0.7.1"
-    "graphql-to-js-client-builder" "1.0.0"
-    "minimist" "1.2.0"
-    "mkdirp" "0.5.1"
+    babel-generator "6.25.0"
+    babel-types "6.25.0"
+    command-line-usage "4.0.0"
+    graphql "0.10.3"
+    graphql-js-client "0.7.0"
+    graphql-js-schema "0.7.1"
+    graphql-to-js-client-builder "1.0.0"
+    minimist "1.2.0"
+    mkdirp "0.5.1"
 
-"graphql-js-client@0.12.0":
-  "integrity" "sha512-d5hPmlzMLq/yZWihd9eaMaRZxcdf+vrFQJxxIep9Tqei+wbesaR1JhkIBU2Czdjz6pCp58msNcyAr1OWTkgZuA=="
-  "resolved" "https://registry.npmjs.org/graphql-js-client/-/graphql-js-client-0.12.0.tgz"
-  "version" "0.12.0"
+graphql-js-client@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.npmjs.org/graphql-js-client/-/graphql-js-client-0.12.0.tgz"
+  integrity sha512-d5hPmlzMLq/yZWihd9eaMaRZxcdf+vrFQJxxIep9Tqei+wbesaR1JhkIBU2Czdjz6pCp58msNcyAr1OWTkgZuA==
 
-"graphql-js-client@0.7.0":
-  "integrity" "sha512-Qb4EDM2s4JVeDVnm1evH8Q7GMR8qwj+jZJFqXsZ8BijADBkr8y9SX1Qd+JP0kdvDSIvQPZ3ePVc0v+lVxwlxSA=="
-  "resolved" "https://registry.npmjs.org/graphql-js-client/-/graphql-js-client-0.7.0.tgz"
-  "version" "0.7.0"
+graphql-js-client@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/graphql-js-client/-/graphql-js-client-0.7.0.tgz"
+  integrity sha512-Qb4EDM2s4JVeDVnm1evH8Q7GMR8qwj+jZJFqXsZ8BijADBkr8y9SX1Qd+JP0kdvDSIvQPZ3ePVc0v+lVxwlxSA==
 
-"graphql-js-schema-fetch@1.1.2":
-  "integrity" "sha1-hTpv2O88E5LqTl6TtWfCdPYZeCY="
-  "resolved" "https://registry.npmjs.org/graphql-js-schema-fetch/-/graphql-js-schema-fetch-1.1.2.tgz"
-  "version" "1.1.2"
+graphql-js-schema-fetch@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/graphql-js-schema-fetch/-/graphql-js-schema-fetch-1.1.2.tgz"
+  integrity sha1-hTpv2O88E5LqTl6TtWfCdPYZeCY=
   dependencies:
-    "graphql" "0.7.0"
-    "minimist" "1.2.0"
-    "node-fetch" "1.6.3"
+    graphql "0.7.0"
+    minimist "1.2.0"
+    node-fetch "1.6.3"
 
-"graphql-js-schema@0.7.1":
-  "integrity" "sha512-bGexqMmJ0lu9SSi0oVa3A+iA0T81q07vgBzFbuO6OT+TY13QEA9Dbo7+uisSmf4O1DKhdWxjIVGGTalA9rCPEQ=="
-  "resolved" "https://registry.npmjs.org/graphql-js-schema/-/graphql-js-schema-0.7.1.tgz"
-  "version" "0.7.1"
+graphql-js-schema@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.npmjs.org/graphql-js-schema/-/graphql-js-schema-0.7.1.tgz"
+  integrity sha512-bGexqMmJ0lu9SSi0oVa3A+iA0T81q07vgBzFbuO6OT+TY13QEA9Dbo7+uisSmf4O1DKhdWxjIVGGTalA9rCPEQ==
   dependencies:
-    "babel-generator" "6.16.0"
-    "babel-template" "6.16.0"
-    "babel-types" "6.16.0"
-    "babylon" "6.11.2"
-    "get-stdin" "5.0.1"
-    "lodash.kebabcase" "4.1.1"
-    "minimist" "1.2.0"
-    "mkdirp" "0.5.1"
-    "rollup" "0.36.3"
-    "tmp" "0.0.29"
+    babel-generator "6.16.0"
+    babel-template "6.16.0"
+    babel-types "6.16.0"
+    babylon "6.11.2"
+    get-stdin "5.0.1"
+    lodash.kebabcase "4.1.1"
+    minimist "1.2.0"
+    mkdirp "0.5.1"
+    rollup "0.36.3"
+    tmp "0.0.29"
 
-"graphql-to-js-client-builder@1.0.0":
-  "integrity" "sha512-p8tBj7nZ53ZoWBQIhnrJ0xxSxu7F8NFNrLxKQMgjLT20Lnz+YN3kPtfxE0OV43PIDTnr/thjKkUSjXo7D7aB+A=="
-  "resolved" "https://registry.npmjs.org/graphql-to-js-client-builder/-/graphql-to-js-client-builder-1.0.0.tgz"
-  "version" "1.0.0"
+graphql-to-js-client-builder@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/graphql-to-js-client-builder/-/graphql-to-js-client-builder-1.0.0.tgz"
+  integrity sha512-p8tBj7nZ53ZoWBQIhnrJ0xxSxu7F8NFNrLxKQMgjLT20Lnz+YN3kPtfxE0OV43PIDTnr/thjKkUSjXo7D7aB+A==
   dependencies:
-    "babel-generator" "6.24.1"
-    "babel-types" "6.24.1"
-    "graphql" "0.9.6"
+    babel-generator "6.24.1"
+    babel-types "6.24.1"
+    graphql "0.9.6"
 
-"graphql@0.10.3":
-  "integrity" "sha1-wxOv1VGOZzNRvuGPtj4qDkh0B6s="
-  "resolved" "https://registry.npmjs.org/graphql/-/graphql-0.10.3.tgz"
-  "version" "0.10.3"
+graphql@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-0.10.3.tgz"
+  integrity sha1-wxOv1VGOZzNRvuGPtj4qDkh0B6s=
   dependencies:
-    "iterall" "^1.1.0"
+    iterall "^1.1.0"
 
-"graphql@0.7.0":
-  "integrity" "sha1-VwFJKDjtxsZzwYQHXrjwaxGn5FE="
-  "resolved" "https://registry.npmjs.org/graphql/-/graphql-0.7.0.tgz"
-  "version" "0.7.0"
+graphql@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-0.7.0.tgz"
+  integrity sha1-VwFJKDjtxsZzwYQHXrjwaxGn5FE=
   dependencies:
-    "iterall" "1.0.2"
+    iterall "1.0.2"
 
-"graphql@0.9.6":
-  "integrity" "sha1-UUQh6dIlwp38j9MFRZq65YgV7yw="
-  "resolved" "https://registry.npmjs.org/graphql/-/graphql-0.9.6.tgz"
-  "version" "0.9.6"
+graphql@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-0.9.6.tgz"
+  integrity sha1-UUQh6dIlwp38j9MFRZq65YgV7yw=
   dependencies:
-    "iterall" "^1.0.0"
+    iterall "^1.0.0"
 
-"growl@1.9.2":
-  "integrity" "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
-  "resolved" "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
-  "version" "1.9.2"
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
 
-"gulp-decompress@^1.2.0":
-  "integrity" "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc="
-  "resolved" "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz"
-  "version" "1.2.0"
+gulp-decompress@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz"
+  integrity sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=
   dependencies:
-    "archive-type" "^3.0.0"
-    "decompress" "^3.0.0"
-    "gulp-util" "^3.0.1"
-    "readable-stream" "^2.0.2"
+    archive-type "^3.0.0"
+    decompress "^3.0.0"
+    gulp-util "^3.0.1"
+    readable-stream "^2.0.2"
 
-"gulp-rename@^1.2.0":
-  "integrity" "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
-  "resolved" "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
-  "version" "1.2.2"
+gulp-rename@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+  integrity sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=
 
-"gulp-sourcemaps@1.6.0":
-  "integrity" "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw="
-  "resolved" "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz"
-  "version" "1.6.0"
+gulp-sourcemaps@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz"
+  integrity sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=
   dependencies:
-    "convert-source-map" "^1.1.1"
-    "graceful-fs" "^4.1.2"
-    "strip-bom" "^2.0.0"
-    "through2" "^2.0.0"
-    "vinyl" "^1.0.0"
+    convert-source-map "^1.1.1"
+    graceful-fs "^4.1.2"
+    strip-bom "^2.0.0"
+    through2 "^2.0.0"
+    vinyl "^1.0.0"
 
-"gulp-util@^3.0.1":
-  "integrity" "sha1-AFTh50RQLifATBh8PsxQXdVLu08="
-  "resolved" "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
-  "version" "3.0.8"
+gulp-util@^3.0.1:
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+  integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
   dependencies:
-    "array-differ" "^1.0.0"
-    "array-uniq" "^1.0.2"
-    "beeper" "^1.0.0"
-    "chalk" "^1.0.0"
-    "dateformat" "^2.0.0"
-    "fancy-log" "^1.1.0"
-    "gulplog" "^1.0.0"
-    "has-gulplog" "^0.1.0"
-    "lodash._reescape" "^3.0.0"
-    "lodash._reevaluate" "^3.0.0"
-    "lodash._reinterpolate" "^3.0.0"
-    "lodash.template" "^3.0.0"
-    "minimist" "^1.1.0"
-    "multipipe" "^0.1.2"
-    "object-assign" "^3.0.0"
-    "replace-ext" "0.0.1"
-    "through2" "^2.0.0"
-    "vinyl" "^0.5.0"
+    array-differ "^1.0.0"
+    array-uniq "^1.0.2"
+    beeper "^1.0.0"
+    chalk "^1.0.0"
+    dateformat "^2.0.0"
+    fancy-log "^1.1.0"
+    gulplog "^1.0.0"
+    has-gulplog "^0.1.0"
+    lodash._reescape "^3.0.0"
+    lodash._reevaluate "^3.0.0"
+    lodash._reinterpolate "^3.0.0"
+    lodash.template "^3.0.0"
+    minimist "^1.1.0"
+    multipipe "^0.1.2"
+    object-assign "^3.0.0"
+    replace-ext "0.0.1"
+    through2 "^2.0.0"
+    vinyl "^0.5.0"
 
-"gulplog@^1.0.0":
-  "integrity" "sha1-4oxNRdBey77YGDY86PnFkmIp/+U="
-  "resolved" "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
-  "version" "1.0.0"
+gulplog@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
+  integrity sha1-4oxNRdBey77YGDY86PnFkmIp/+U=
   dependencies:
-    "glogg" "^1.0.0"
+    glogg "^1.0.0"
 
-"handlebars@^4.0.5", "handlebars@^4.2.0":
-  "integrity" "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA=="
-  "resolved" "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz"
-  "version" "4.7.7"
+handlebars@^4.0.5, handlebars@^4.2.0:
+  version "4.7.7"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
-    "minimist" "^1.2.5"
-    "neo-async" "^2.6.0"
-    "source-map" "^0.6.1"
-    "wordwrap" "^1.0.0"
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
-    "uglify-js" "^3.1.4"
+    uglify-js "^3.1.4"
 
-"har-schema@^1.0.5":
-  "integrity" "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-  "resolved" "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-  "version" "1.0.5"
+har-schema@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
 
-"har-validator@~4.2.1":
-  "integrity" "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
-  "resolved" "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
-  "version" "4.2.1"
+har-validator@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+  integrity sha1-M0gdDxu/9gDdID11gSpqX7oALio=
   dependencies:
-    "ajv" "^4.9.1"
-    "har-schema" "^1.0.5"
+    ajv "^4.9.1"
+    har-schema "^1.0.5"
 
-"has-ansi@^0.1.0":
-  "integrity" "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4="
-  "resolved" "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
-  "version" "0.1.0"
+has-ansi@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
+  integrity sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=
   dependencies:
-    "ansi-regex" "^0.2.0"
+    ansi-regex "^0.2.0"
 
-"has-ansi@^2.0.0":
-  "integrity" "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
-  "resolved" "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-  "version" "2.0.0"
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
-    "ansi-regex" "^2.0.0"
+    ansi-regex "^2.0.0"
 
-"has-flag@^1.0.0":
-  "integrity" "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-  "resolved" "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-  "version" "1.0.0"
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
-"has-flag@^3.0.0":
-  "integrity" "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-  "resolved" "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
-  "version" "3.0.0"
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-"has-glob@^0.1.1":
-  "integrity" "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk="
-  "resolved" "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz"
-  "version" "0.1.1"
+has-glob@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz"
+  integrity sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=
   dependencies:
-    "is-glob" "^2.0.1"
+    is-glob "^2.0.1"
 
-"has-gulplog@^0.1.0":
-  "integrity" "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4="
-  "resolved" "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
-  "version" "0.1.0"
+has-gulplog@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
+  integrity sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=
   dependencies:
-    "sparkles" "^1.0.0"
+    sparkles "^1.0.0"
 
-"has-symbol-support-x@^1.4.0":
-  "integrity" "sha512-F1NtLDtW9NyUrS3faUcI1yVFHCTXyzPb1jfrZBQi5NHxFPlXxZnFLFGzfA2DsdmgCxv2MZ0+bfcgC4EZTmk4SQ=="
-  "resolved" "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.0.tgz"
-  "version" "1.4.0"
+has-symbol-support-x@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.0.tgz"
+  integrity sha512-F1NtLDtW9NyUrS3faUcI1yVFHCTXyzPb1jfrZBQi5NHxFPlXxZnFLFGzfA2DsdmgCxv2MZ0+bfcgC4EZTmk4SQ==
 
-"has-to-string-tag-x@^1.2.0":
-  "integrity" "sha512-R3OdOP9j6AH5hS1yXeu9wAS+iKSZQx/CC6aMdN6WiaqPlBoA2S+47MtoMsZgKr2m0eAJ+73WWGX0RaFFE5XWKA=="
-  "resolved" "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz"
-  "version" "1.4.0"
+has-to-string-tag-x@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz"
+  integrity sha512-R3OdOP9j6AH5hS1yXeu9wAS+iKSZQx/CC6aMdN6WiaqPlBoA2S+47MtoMsZgKr2m0eAJ+73WWGX0RaFFE5XWKA==
   dependencies:
-    "has-symbol-support-x" "^1.4.0"
+    has-symbol-support-x "^1.4.0"
 
-"has-value@^0.3.1":
-  "integrity" "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8="
-  "resolved" "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz"
-  "version" "0.3.1"
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz"
+  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
   dependencies:
-    "get-value" "^2.0.3"
-    "has-values" "^0.1.4"
-    "isobject" "^2.0.0"
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
 
-"has-value@^1.0.0":
-  "integrity" "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc="
-  "resolved" "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz"
-  "version" "1.0.0"
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz"
+  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
   dependencies:
-    "get-value" "^2.0.6"
-    "has-values" "^1.0.0"
-    "isobject" "^3.0.0"
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
 
-"has-values@^0.1.4":
-  "integrity" "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-  "resolved" "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz"
-  "version" "0.1.4"
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz"
+  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
 
-"has-values@^1.0.0":
-  "integrity" "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8="
-  "resolved" "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz"
-  "version" "1.0.0"
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
   dependencies:
-    "is-number" "^3.0.0"
-    "kind-of" "^4.0.0"
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
-"has@^1.0.1":
-  "integrity" "sha1-hGFzP1OLCDfJNh45qauelwTcLyg="
-  "resolved" "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
-  "version" "1.0.1"
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+  integrity sha1-hGFzP1OLCDfJNh45qauelwTcLyg=
   dependencies:
-    "function-bind" "^1.0.2"
+    function-bind "^1.0.2"
 
-"hash.js@^1.0.0", "hash.js@^1.0.3":
-  "integrity" "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM="
-  "resolved" "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
-  "version" "1.0.3"
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+  integrity sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=
   dependencies:
-    "inherits" "^2.0.1"
+    inherits "^2.0.1"
 
-"hawk@~3.1.3":
-  "integrity" "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
-  "resolved" "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-  "version" "3.1.3"
+hawk@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
+  integrity sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=
   dependencies:
-    "boom" "2.x.x"
-    "cryptiles" "2.x.x"
-    "hoek" "2.x.x"
-    "sntp" "1.x.x"
+    boom "0.4.x"
+    cryptiles "0.2.x"
+    hoek "0.9.x"
+    sntp "0.2.x"
 
-"hawk@1.1.1":
-  "integrity" "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk="
-  "resolved" "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
-  "version" "1.1.1"
+hawk@~3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+  integrity sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=
   dependencies:
-    "boom" "0.4.x"
-    "cryptiles" "0.2.x"
-    "hoek" "0.9.x"
-    "sntp" "0.2.x"
+    boom "2.x.x"
+    cryptiles "2.x.x"
+    hoek "2.x.x"
+    sntp "1.x.x"
 
-"he@^1.1.1":
-  "integrity" "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
-  "resolved" "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
-  "version" "1.1.1"
+he@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
+  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
-"hmac-drbg@^1.0.0":
-  "integrity" "sha1-PbRx9FquSplKBogyIXH1G4uRvuU="
-  "resolved" "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz"
-  "version" "1.0.0"
+hmac-drbg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz"
+  integrity sha1-PbRx9FquSplKBogyIXH1G4uRvuU=
   dependencies:
-    "hash.js" "^1.0.3"
-    "minimalistic-assert" "^1.0.0"
-    "minimalistic-crypto-utils" "^1.0.1"
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
-"hoek@0.9.x":
-  "integrity" "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
-  "resolved" "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-  "version" "0.9.1"
+hoek@0.9.x:
+  version "0.9.1"
+  resolved "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+  integrity sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=
 
-"hoek@2.x.x":
-  "integrity" "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-  "resolved" "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-  "version" "2.16.3"
+hoek@2.x.x:
+  version "2.16.3"
+  resolved "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+  integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
-"hoek@4.x.x":
-  "integrity" "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-  "resolved" "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
-  "version" "4.2.0"
+hoek@4.x.x:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+  integrity sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==
 
-"home-or-tmp@^2.0.0":
-  "integrity" "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
-  "resolved" "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz"
-  "version" "2.0.0"
+home-or-tmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz"
+  integrity sha1-42w/LSyufXRqhX440Y1fMqeILbg=
   dependencies:
-    "os-homedir" "^1.0.0"
-    "os-tmpdir" "^1.0.1"
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.1"
 
-"homedir-polyfill@^1.0.0":
-  "integrity" "sha1-TCu8inWJmP7r9e1oWA921GdotLw="
-  "resolved" "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
-  "version" "1.0.1"
+homedir-polyfill@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
+  integrity sha1-TCu8inWJmP7r9e1oWA921GdotLw=
   dependencies:
-    "parse-passwd" "^1.0.0"
+    parse-passwd "^1.0.0"
 
-"http-proxy@^1.8.1":
-  "integrity" "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I="
-  "resolved" "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz"
-  "version" "1.16.2"
+http-proxy@^1.8.1:
+  version "1.16.2"
+  resolved "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz"
+  integrity sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=
   dependencies:
-    "eventemitter3" "1.x.x"
-    "requires-port" "1.x.x"
+    eventemitter3 "1.x.x"
+    requires-port "1.x.x"
 
-"http-server@0.10.0":
-  "integrity" "sha1-sqRGsWqduH7TxiK6m+sbCFsSNKc="
-  "resolved" "https://registry.npmjs.org/http-server/-/http-server-0.10.0.tgz"
-  "version" "0.10.0"
+http-server@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.npmjs.org/http-server/-/http-server-0.10.0.tgz"
+  integrity sha1-sqRGsWqduH7TxiK6m+sbCFsSNKc=
   dependencies:
-    "colors" "1.0.3"
-    "corser" "~2.0.0"
-    "ecstatic" "^2.0.0"
-    "http-proxy" "^1.8.1"
-    "opener" "~1.4.0"
-    "optimist" "0.6.x"
-    "portfinder" "^1.0.13"
-    "union" "~0.4.3"
+    colors "1.0.3"
+    corser "~2.0.0"
+    ecstatic "^2.0.0"
+    http-proxy "^1.8.1"
+    opener "~1.4.0"
+    optimist "0.6.x"
+    portfinder "^1.0.13"
+    union "~0.4.3"
 
-"http-signature@~0.10.0":
-  "integrity" "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY="
-  "resolved" "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
-  "version" "0.10.1"
+http-signature@~0.10.0:
+  version "0.10.1"
+  resolved "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
+  integrity sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=
   dependencies:
-    "asn1" "0.1.11"
-    "assert-plus" "^0.1.5"
-    "ctype" "0.5.3"
+    asn1 "0.1.11"
+    assert-plus "^0.1.5"
+    ctype "0.5.3"
 
-"http-signature@~1.1.0":
-  "integrity" "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
-  "resolved" "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-  "version" "1.1.1"
+http-signature@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+  integrity sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=
   dependencies:
-    "assert-plus" "^0.2.0"
-    "jsprim" "^1.2.2"
-    "sshpk" "^1.7.0"
+    assert-plus "^0.2.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
 
-"iconv-lite@~0.4.13":
-  "integrity" "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
-  "resolved" "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
-  "version" "0.4.15"
+iconv-lite@~0.4.13:
+  version "0.4.15"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+  integrity sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=
 
-"idb-wrapper@^1.5.0":
-  "integrity" "sha1-ajJnASLhc6hOzFz6lmj6LOsiGwQ="
-  "resolved" "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.1.tgz"
-  "version" "1.7.1"
+idb-wrapper@^1.5.0:
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.1.tgz"
+  integrity sha1-ajJnASLhc6hOzFz6lmj6LOsiGwQ=
 
-"ieee754@^1.1.4":
-  "integrity" "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
-  "resolved" "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
-  "version" "1.1.8"
+ieee754@^1.1.4:
+  version "1.1.8"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
-"ignore@^3.0.11", "ignore@^3.1.2", "ignore@^3.1.5":
-  "integrity" "sha1-JujaBkS+C7TLOVFvbHnw4PT/5Iw="
-  "resolved" "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz"
-  "version" "3.2.6"
+ignore@^3.0.11, ignore@^3.1.2, ignore@^3.1.5:
+  version "3.2.6"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz"
+  integrity sha1-JujaBkS+C7TLOVFvbHnw4PT/5Iw=
 
-"imurmurhash@^0.1.4":
-  "integrity" "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-  "resolved" "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-  "version" "0.1.4"
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-"in-publish@^2.0.0":
-  "integrity" "sha1-4g/146KvwmkDILbcVSaCqcf631E="
-  "resolved" "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
-  "version" "2.0.0"
+in-publish@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
+  integrity sha1-4g/146KvwmkDILbcVSaCqcf631E=
 
-"indexof@~0.0.1":
-  "integrity" "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-  "resolved" "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-  "version" "0.0.1"
+indexof@~0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
-"inflight@^1.0.4":
-  "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
-  "resolved" "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-  "version" "1.0.6"
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
-    "once" "^1.3.0"
-    "wrappy" "1"
+    once "^1.3.0"
+    wrappy "1"
 
-"inherits@^2.0.1", "inherits@^2.0.3", "inherits@~2.0.1", "inherits@~2.0.3", "inherits@2":
-  "integrity" "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-  "resolved" "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-  "version" "2.0.3"
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-"ini@^1.3.4":
-  "integrity" "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-  "resolved" "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-  "version" "1.3.4"
+ini@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+  integrity sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=
 
-"ini@~1.3.0":
-  "integrity" "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-  "resolved" "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz"
-  "version" "1.3.5"
+ini@~1.3.0:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz"
+  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-"inquirer@^0.12.0":
-  "integrity" "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34="
-  "resolved" "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz"
-  "version" "0.12.0"
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz"
+  integrity sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=
   dependencies:
-    "ansi-escapes" "^1.1.0"
-    "ansi-regex" "^2.0.0"
-    "chalk" "^1.0.0"
-    "cli-cursor" "^1.0.1"
-    "cli-width" "^2.0.0"
-    "figures" "^1.3.5"
-    "lodash" "^4.3.0"
-    "readline2" "^1.0.1"
-    "run-async" "^0.1.0"
-    "rx-lite" "^3.1.2"
-    "string-width" "^1.0.1"
-    "strip-ansi" "^3.0.0"
-    "through" "^2.3.6"
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
 
-"invariant@^2.2.0", "invariant@^2.2.2":
-  "integrity" "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
-  "resolved" "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
-  "version" "2.2.2"
+invariant@^2.2.0, invariant@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+  integrity sha1-nh9WrArNtr8wMwbzOL47IErmA2A=
   dependencies:
-    "loose-envify" "^1.0.0"
+    loose-envify "^1.0.0"
 
-"ip-regex@^1.0.1":
-  "integrity" "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
-  "resolved" "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
-  "version" "1.0.3"
+ip-regex@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+  integrity sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=
 
-"is-absolute@^0.1.5", "is-absolute@^0.1.7":
-  "integrity" "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8="
-  "resolved" "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
-  "version" "0.1.7"
+is-absolute@^0.1.5, is-absolute@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
+  integrity sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=
   dependencies:
-    "is-relative" "^0.1.0"
+    is-relative "^0.1.0"
 
-"is-accessor-descriptor@^0.1.6":
-  "integrity" "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY="
-  "resolved" "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz"
-  "version" "0.1.6"
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz"
+  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
   dependencies:
-    "kind-of" "^3.0.2"
+    kind-of "^3.0.2"
 
-"is-accessor-descriptor@^1.0.0":
-  "integrity" "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ=="
-  "resolved" "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz"
-  "version" "1.0.0"
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz"
+  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
-    "kind-of" "^6.0.0"
+    kind-of "^6.0.0"
 
-"is-arrayish@^0.2.1":
-  "integrity" "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-  "resolved" "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-  "version" "0.2.1"
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
-"is-binary-path@^1.0.0":
-  "integrity" "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg="
-  "resolved" "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
-  "version" "1.0.1"
+is-binary-path@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
+  integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
   dependencies:
-    "binary-extensions" "^1.0.0"
+    binary-extensions "^1.0.0"
 
-"is-buffer@^1.1.5":
-  "integrity" "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-  "resolved" "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-  "version" "1.1.6"
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-"is-bzip2@^1.0.0":
-  "integrity" "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w="
-  "resolved" "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
-  "version" "1.0.0"
+is-bzip2@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+  integrity sha1-XuWOqlounIDiFAe+3yOuWsCRs/w=
 
-"is-callable@^1.1.1", "is-callable@^1.1.3":
-  "integrity" "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
-  "resolved" "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-  "version" "1.1.3"
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
+  integrity sha1-hut1OSgF3cM69xySoO7fdO52BLI=
 
-"is-data-descriptor@^0.1.4":
-  "integrity" "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y="
-  "resolved" "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz"
-  "version" "0.1.4"
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz"
+  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
   dependencies:
-    "kind-of" "^3.0.2"
+    kind-of "^3.0.2"
 
-"is-data-descriptor@^1.0.0":
-  "integrity" "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ=="
-  "resolved" "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz"
-  "version" "1.0.0"
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz"
+  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
-    "kind-of" "^6.0.0"
+    kind-of "^6.0.0"
 
-"is-date-object@^1.0.1":
-  "integrity" "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-  "resolved" "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
-  "version" "1.0.1"
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
-"is-descriptor@^0.1.0":
-  "integrity" "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg=="
-  "resolved" "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz"
-  "version" "0.1.6"
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz"
+  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
   dependencies:
-    "is-accessor-descriptor" "^0.1.6"
-    "is-data-descriptor" "^0.1.4"
-    "kind-of" "^5.0.0"
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
 
-"is-descriptor@^1.0.0", "is-descriptor@^1.0.2":
-  "integrity" "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg=="
-  "resolved" "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz"
-  "version" "1.0.2"
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz"
+  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
   dependencies:
-    "is-accessor-descriptor" "^1.0.0"
-    "is-data-descriptor" "^1.0.0"
-    "kind-of" "^6.0.2"
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
-"is-dotfile@^1.0.0":
-  "integrity" "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-  "resolved" "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
-  "version" "1.0.3"
+is-dotfile@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+  integrity sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
 
-"is-equal-shallow@^0.1.3":
-  "integrity" "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ="
-  "resolved" "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-  "version" "0.1.3"
+is-equal-shallow@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+  integrity sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=
   dependencies:
-    "is-primitive" "^2.0.0"
+    is-primitive "^2.0.0"
 
-"is-error@^2.2.0":
-  "integrity" "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
-  "resolved" "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz"
-  "version" "2.2.1"
+is-error@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz"
+  integrity sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=
 
-"is-extendable@^0.1.0", "is-extendable@^0.1.1":
-  "integrity" "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-  "resolved" "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-  "version" "0.1.1"
+is-extendable@^0.1.0, is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
-"is-extendable@^1.0.1":
-  "integrity" "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA=="
-  "resolved" "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz"
-  "version" "1.0.1"
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz"
+  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
-    "is-plain-object" "^2.0.4"
+    is-plain-object "^2.0.4"
 
-"is-extglob@^1.0.0":
-  "integrity" "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-  "resolved" "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-  "version" "1.0.0"
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
 
-"is-extglob@^2.1.0":
-  "integrity" "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-  "resolved" "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
-  "version" "2.1.1"
+is-extglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-"is-finite@^1.0.0":
-  "integrity" "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
-  "resolved" "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-  "version" "1.0.2"
+is-finite@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+  integrity sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=
   dependencies:
-    "number-is-nan" "^1.0.0"
+    number-is-nan "^1.0.0"
 
-"is-fullwidth-code-point@^1.0.0":
-  "integrity" "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
-  "resolved" "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-  "version" "1.0.0"
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
-    "number-is-nan" "^1.0.0"
+    number-is-nan "^1.0.0"
 
-"is-fullwidth-code-point@^2.0.0":
-  "integrity" "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-  "resolved" "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-  "version" "2.0.0"
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
-"is-glob@^2.0.0", "is-glob@^2.0.1":
-  "integrity" "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
-  "resolved" "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-  "version" "2.0.1"
+is-glob@^2.0.0, is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
   dependencies:
-    "is-extglob" "^1.0.0"
+    is-extglob "^1.0.0"
 
-"is-glob@^3.1.0":
-  "integrity" "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo="
-  "resolved" "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz"
-  "version" "3.1.0"
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz"
+  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
   dependencies:
-    "is-extglob" "^2.1.0"
+    is-extglob "^2.1.0"
 
-"is-gzip@^1.0.0":
-  "integrity" "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
-  "resolved" "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
-  "version" "1.0.0"
+is-gzip@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+  integrity sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=
 
-"is-invalid-path@^0.1.0":
-  "integrity" "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ="
-  "resolved" "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz"
-  "version" "0.1.0"
+is-invalid-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz"
+  integrity sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=
   dependencies:
-    "is-glob" "^2.0.0"
+    is-glob "^2.0.0"
 
-"is-module@^1.0.0":
-  "integrity" "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
-  "resolved" "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz"
-  "version" "1.0.0"
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
 
-"is-my-json-valid@^2.10.0":
-  "integrity" "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
-  "resolved" "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz"
-  "version" "2.16.0"
+is-my-json-valid@^2.10.0:
+  version "2.16.0"
+  resolved "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz"
+  integrity sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=
   dependencies:
-    "generate-function" "^2.0.0"
-    "generate-object-property" "^1.1.0"
-    "jsonpointer" "^4.0.0"
-    "xtend" "^4.0.0"
+    generate-function "^2.0.0"
+    generate-object-property "^1.1.0"
+    jsonpointer "^4.0.0"
+    xtend "^4.0.0"
 
-"is-natural-number@^2.0.0":
-  "integrity" "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec="
-  "resolved" "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz"
-  "version" "2.1.1"
+is-natural-number@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz"
+  integrity sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec=
 
-"is-natural-number@^4.0.1":
-  "integrity" "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
-  "resolved" "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz"
-  "version" "4.0.1"
+is-natural-number@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz"
+  integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
 
-"is-number@^2.1.0":
-  "integrity" "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
-  "resolved" "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-  "version" "2.1.0"
+is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+  integrity sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=
   dependencies:
-    "kind-of" "^3.0.2"
+    kind-of "^3.0.2"
 
-"is-number@^3.0.0":
-  "integrity" "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU="
-  "resolved" "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
-  "version" "3.0.0"
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
+  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
-    "kind-of" "^3.0.2"
+    kind-of "^3.0.2"
 
-"is-number@^4.0.0":
-  "integrity" "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-  "resolved" "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz"
-  "version" "4.0.0"
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz"
+  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
-"is-obj@^1.0.0":
-  "integrity" "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-  "resolved" "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
-  "version" "1.0.1"
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
-"is-object@^1.0.1":
-  "integrity" "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-  "resolved" "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
-  "version" "1.0.1"
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
-"is-object@~0.1.2":
-  "integrity" "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc="
-  "resolved" "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz"
-  "version" "0.1.2"
+is-object@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz"
+  integrity sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=
 
-"is-path-cwd@^1.0.0":
-  "integrity" "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-  "resolved" "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-  "version" "1.0.0"
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
 
-"is-path-in-cwd@^1.0.0":
-  "integrity" "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw="
-  "resolved" "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
-  "version" "1.0.0"
+is-path-in-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
+  integrity sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=
   dependencies:
-    "is-path-inside" "^1.0.0"
+    is-path-inside "^1.0.0"
 
-"is-path-inside@^1.0.0":
-  "integrity" "sha1-/AbloWg/vaE95mev9xe7wQpI838="
-  "resolved" "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-  "version" "1.0.0"
+is-path-inside@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+  integrity sha1-/AbloWg/vaE95mev9xe7wQpI838=
   dependencies:
-    "path-is-inside" "^1.0.1"
+    path-is-inside "^1.0.1"
 
-"is-plain-obj@^1.0.0", "is-plain-obj@^1.1.0":
-  "integrity" "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-  "resolved" "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-  "version" "1.1.0"
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-"is-plain-object@^2.0.1", "is-plain-object@^2.0.3", "is-plain-object@^2.0.4":
-  "integrity" "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="
-  "resolved" "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
-  "version" "2.0.4"
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
-    "isobject" "^3.0.1"
+    isobject "^3.0.1"
 
-"is-posix-bracket@^0.1.0":
-  "integrity" "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-  "resolved" "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-  "version" "0.1.1"
+is-posix-bracket@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+  integrity sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=
 
-"is-primitive@^2.0.0":
-  "integrity" "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-  "resolved" "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-  "version" "2.0.0"
+is-primitive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+  integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-"is-property@^1.0.0":
-  "integrity" "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-  "resolved" "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-  "version" "1.0.2"
+is-property@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
-"is-redirect@^1.0.0":
-  "integrity" "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-  "resolved" "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
-  "version" "1.0.0"
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
-"is-regex@^1.0.4":
-  "integrity" "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE="
-  "resolved" "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
-  "version" "1.0.4"
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
-    "has" "^1.0.1"
+    has "^1.0.1"
 
-"is-relative@^0.1.0":
-  "integrity" "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI="
-  "resolved" "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-  "version" "0.1.3"
+is-relative@^0.1.0:
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+  integrity sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=
 
-"is-resolvable@^1.0.0":
-  "integrity" "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI="
-  "resolved" "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
-  "version" "1.0.0"
+is-resolvable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
+  integrity sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=
   dependencies:
-    "tryit" "^1.0.1"
+    tryit "^1.0.1"
 
-"is-retry-allowed@^1.0.0":
-  "integrity" "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-  "resolved" "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
-  "version" "1.1.0"
+is-retry-allowed@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
+  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
-"is-stream@^1.0.0", "is-stream@^1.0.1", "is-stream@^1.1.0":
-  "integrity" "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-  "resolved" "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-  "version" "1.1.0"
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
-"is-symbol@^1.0.1":
-  "integrity" "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
-  "resolved" "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-  "version" "1.0.1"
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+  integrity sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=
 
-"is-tar@^1.0.0":
-  "integrity" "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0="
-  "resolved" "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
-  "version" "1.0.0"
+is-tar@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+  integrity sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0=
 
-"is-typedarray@~1.0.0":
-  "integrity" "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-  "resolved" "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-  "version" "1.0.0"
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-"is-url@^1.2.0":
-  "integrity" "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
-  "resolved" "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz"
-  "version" "1.2.2"
+is-url@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz"
+  integrity sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=
 
-"is-utf8@^0.2.0":
-  "integrity" "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-  "resolved" "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-  "version" "0.2.1"
+is-utf8@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-"is-valid-glob@^0.3.0":
-  "integrity" "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
-  "resolved" "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
-  "version" "0.3.0"
+is-valid-glob@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
+  integrity sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=
 
-"is-valid-path@^0.1.1":
-  "integrity" "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8="
-  "resolved" "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz"
-  "version" "0.1.1"
+is-valid-path@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz"
+  integrity sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=
   dependencies:
-    "is-invalid-path" "^0.1.0"
+    is-invalid-path "^0.1.0"
 
-"is-windows@^0.2.0":
-  "integrity" "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
-  "resolved" "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
-  "version" "0.2.0"
+is-windows@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+  integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
 
-"is-windows@^1.0.2":
-  "integrity" "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-  "resolved" "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz"
-  "version" "1.0.2"
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-"is-zip@^1.0.0":
-  "integrity" "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU="
-  "resolved" "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
-  "version" "1.0.0"
+is-zip@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+  integrity sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=
 
-"is@~0.2.6":
-  "integrity" "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
-  "resolved" "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
-  "version" "0.2.7"
+is@~0.2.6:
+  version "0.2.7"
+  resolved "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
+  integrity sha1-OzSixI81mXLzUEKEkZOucmS2NWI=
 
-"isarray@^1.0.0", "isarray@~1.0.0", "isarray@1.0.0":
-  "integrity" "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-  "resolved" "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-  "version" "1.0.0"
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-"isarray@0.0.1":
-  "integrity" "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-  "resolved" "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-  "version" "0.0.1"
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-"isbuffer@~0.0.0":
-  "integrity" "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
-  "resolved" "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz"
-  "version" "0.0.0"
+isbuffer@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz"
+  integrity sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s=
 
-"isemail@2.x.x":
-  "integrity" "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
-  "resolved" "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz"
-  "version" "2.2.1"
+isemail@2.x.x:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz"
+  integrity sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=
 
-"isexe@^2.0.0":
-  "integrity" "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-  "resolved" "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-  "version" "2.0.0"
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-"isobject@^2.0.0":
-  "integrity" "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
-  "resolved" "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
-  "version" "2.1.0"
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
-    "isarray" "1.0.0"
+    isarray "1.0.0"
 
-"isobject@^3.0.0", "isobject@^3.0.1":
-  "integrity" "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-  "resolved" "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
-  "version" "3.0.1"
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-"isstream@~0.1.2":
-  "integrity" "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-  "resolved" "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-  "version" "0.1.2"
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-"isurl@^1.0.0-alpha5":
-  "integrity" "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w=="
-  "resolved" "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz"
-  "version" "1.0.0"
+isurl@^1.0.0-alpha5:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz"
+  integrity sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==
   dependencies:
-    "has-to-string-tag-x" "^1.2.0"
-    "is-object" "^1.0.1"
+    has-to-string-tag-x "^1.2.0"
+    is-object "^1.0.1"
 
-"items@2.x.x":
-  "integrity" "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
-  "resolved" "https://registry.npmjs.org/items/-/items-2.1.1.tgz"
-  "version" "2.1.1"
+items@2.x.x:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/items/-/items-2.1.1.tgz"
+  integrity sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=
 
-"iterall@^1.0.0", "iterall@^1.1.0":
-  "integrity" "sha1-9/CvEemgTsZCYmD1AZ2fzKTVAhQ="
-  "resolved" "https://registry.npmjs.org/iterall/-/iterall-1.1.1.tgz"
-  "version" "1.1.1"
+iterall@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/iterall/-/iterall-1.0.2.tgz"
+  integrity sha1-QaLpbOntpeYcdn7l3DEjc7sEbpE=
 
-"iterall@1.0.2":
-  "integrity" "sha1-QaLpbOntpeYcdn7l3DEjc7sEbpE="
-  "resolved" "https://registry.npmjs.org/iterall/-/iterall-1.0.2.tgz"
-  "version" "1.0.2"
+iterall@^1.0.0, iterall@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/iterall/-/iterall-1.1.1.tgz"
+  integrity sha1-9/CvEemgTsZCYmD1AZ2fzKTVAhQ=
 
-"jmespath@0.15.0":
-  "integrity" "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-  "resolved" "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
-  "version" "0.15.0"
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
-"joi@^9.2.0":
-  "integrity" "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to="
-  "resolved" "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz"
-  "version" "9.2.0"
+joi@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz"
+  integrity sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=
   dependencies:
-    "hoek" "4.x.x"
-    "isemail" "2.x.x"
-    "items" "2.x.x"
-    "moment" "2.x.x"
-    "topo" "2.x.x"
+    hoek "4.x.x"
+    isemail "2.x.x"
+    items "2.x.x"
+    moment "2.x.x"
+    topo "2.x.x"
 
-"jquery@3.2.1":
-  "integrity" "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
-  "resolved" "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz"
-  "version" "3.2.1"
+jquery@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz"
+  integrity sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=
 
-"js-string-escape@^1.0.1":
-  "integrity" "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
-  "resolved" "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
-  "version" "1.0.1"
+js-string-escape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
+  integrity sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=
 
-"js-tokens@^3.0.0":
-  "integrity" "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
-  "resolved" "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-  "version" "3.0.1"
+js-tokens@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+  integrity sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=
 
-"js-tokens@^3.0.2":
-  "integrity" "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-  "resolved" "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-  "version" "3.0.2"
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-"js-tokens@^4.0.0":
-  "integrity" "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-  "resolved" "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
-  "version" "4.0.0"
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-"js-yaml@^3.5.1":
-  "integrity" "sha1-AtPiwPa+qyAkjUEsNSIDgn14ZyE="
-  "resolved" "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.2.tgz"
-  "version" "3.8.2"
+js-yaml@^3.5.1:
+  version "3.8.2"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.2.tgz"
+  integrity sha1-AtPiwPa+qyAkjUEsNSIDgn14ZyE=
   dependencies:
-    "argparse" "^1.0.7"
-    "esprima" "^3.1.1"
+    argparse "^1.0.7"
+    esprima "^3.1.1"
 
-"js2xmlparser@^4.0.0":
-  "integrity" "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw=="
-  "resolved" "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz"
-  "version" "4.0.0"
+js2xmlparser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz"
+  integrity sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==
   dependencies:
-    "xmlcreate" "^2.0.0"
+    xmlcreate "^2.0.0"
 
-"jsbn@~0.1.0":
-  "integrity" "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-  "resolved" "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-  "version" "0.1.1"
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-"jsdoc-api@^5.0.3":
-  "integrity" "sha512-7F/FR1DCRmRFlyuccpeRwW/4H5GtUD9detREDO/gxLjyEaVfRdD1JDzwZ4tMg32f0jP97PCDTy9CdSr8mW0txQ=="
-  "resolved" "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.3.tgz"
-  "version" "5.0.3"
+jsdoc-api@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.3.tgz"
+  integrity sha512-7F/FR1DCRmRFlyuccpeRwW/4H5GtUD9detREDO/gxLjyEaVfRdD1JDzwZ4tMg32f0jP97PCDTy9CdSr8mW0txQ==
   dependencies:
-    "array-back" "^4.0.0"
-    "cache-point" "^0.4.1"
-    "collect-all" "^1.0.3"
-    "file-set" "^2.0.1"
-    "fs-then-native" "^2.0.0"
-    "jsdoc" "^3.6.3"
-    "object-to-spawn-args" "^1.1.1"
-    "temp-path" "^1.0.0"
-    "walk-back" "^3.0.1"
+    array-back "^4.0.0"
+    cache-point "^0.4.1"
+    collect-all "^1.0.3"
+    file-set "^2.0.1"
+    fs-then-native "^2.0.0"
+    jsdoc "^3.6.3"
+    object-to-spawn-args "^1.1.1"
+    temp-path "^1.0.0"
+    walk-back "^3.0.1"
 
-"jsdoc-export-default-interop@0.3.1":
-  "integrity" "sha1-Ri+p+bSiqwag9NBiQUPQLlui0F8="
-  "resolved" "https://registry.npmjs.org/jsdoc-export-default-interop/-/jsdoc-export-default-interop-0.3.1.tgz"
-  "version" "0.3.1"
+jsdoc-export-default-interop@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/jsdoc-export-default-interop/-/jsdoc-export-default-interop-0.3.1.tgz"
+  integrity sha1-Ri+p+bSiqwag9NBiQUPQLlui0F8=
   dependencies:
-    "in-publish" "^2.0.0"
-    "lodash" "^4.0.1"
+    in-publish "^2.0.0"
+    lodash "^4.0.1"
 
-"jsdoc-parse@^4.0.1":
-  "integrity" "sha512-qIObw8yqYZjrP2qxWROB5eLQFLTUX2jRGLhW9hjo2CC2fQVlskidCIzjCoctwsDvauBp2a/lR31jkSleczSo8Q=="
-  "resolved" "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-4.0.1.tgz"
-  "version" "4.0.1"
+jsdoc-parse@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-4.0.1.tgz"
+  integrity sha512-qIObw8yqYZjrP2qxWROB5eLQFLTUX2jRGLhW9hjo2CC2fQVlskidCIzjCoctwsDvauBp2a/lR31jkSleczSo8Q==
   dependencies:
-    "array-back" "^4.0.0"
-    "lodash.omit" "^4.5.0"
-    "lodash.pick" "^4.4.0"
-    "reduce-extract" "^1.0.0"
-    "sort-array" "^2.0.0"
-    "test-value" "^3.0.0"
+    array-back "^4.0.0"
+    lodash.omit "^4.5.0"
+    lodash.pick "^4.4.0"
+    reduce-extract "^1.0.0"
+    sort-array "^2.0.0"
+    test-value "^3.0.0"
 
-"jsdoc-to-markdown@5.0.1":
-  "integrity" "sha512-l+2sPeNM0V4iYHMS5IGhwKDtCTAW0sF4PAXX1AX9f7r6xfszTB8bqlqNR8ymvU85L9U2kEQ/Qemd5NrtX5DR0w=="
-  "resolved" "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.1.tgz"
-  "version" "5.0.1"
+jsdoc-to-markdown@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.1.tgz"
+  integrity sha512-l+2sPeNM0V4iYHMS5IGhwKDtCTAW0sF4PAXX1AX9f7r6xfszTB8bqlqNR8ymvU85L9U2kEQ/Qemd5NrtX5DR0w==
   dependencies:
-    "array-back" "^4.0.0"
-    "command-line-tool" "^0.8.0"
-    "config-master" "^3.1.0"
-    "dmd" "^4.0.2"
-    "jsdoc-api" "^5.0.3"
-    "jsdoc-parse" "^4.0.1"
-    "walk-back" "^3.0.1"
+    array-back "^4.0.0"
+    command-line-tool "^0.8.0"
+    config-master "^3.1.0"
+    dmd "^4.0.2"
+    jsdoc-api "^5.0.3"
+    jsdoc-parse "^4.0.1"
+    walk-back "^3.0.1"
 
-"jsdoc@^3.6.3", "jsdoc@3.6.3":
-  "integrity" "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A=="
-  "resolved" "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz"
-  "version" "3.6.3"
+jsdoc@3.6.3, jsdoc@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz"
+  integrity sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==
   dependencies:
     "@babel/parser" "^7.4.4"
-    "bluebird" "^3.5.4"
-    "catharsis" "^0.8.11"
-    "escape-string-regexp" "^2.0.0"
-    "js2xmlparser" "^4.0.0"
-    "klaw" "^3.0.0"
-    "markdown-it" "^8.4.2"
-    "markdown-it-anchor" "^5.0.2"
-    "marked" "^0.7.0"
-    "mkdirp" "^0.5.1"
-    "requizzle" "^0.2.3"
-    "strip-json-comments" "^3.0.1"
-    "taffydb" "2.6.2"
-    "underscore" "~1.9.1"
+    bluebird "^3.5.4"
+    catharsis "^0.8.11"
+    escape-string-regexp "^2.0.0"
+    js2xmlparser "^4.0.0"
+    klaw "^3.0.0"
+    markdown-it "^8.4.2"
+    markdown-it-anchor "^5.0.2"
+    marked "^0.7.0"
+    mkdirp "^0.5.1"
+    requizzle "^0.2.3"
+    strip-json-comments "^3.0.1"
+    taffydb "2.6.2"
+    underscore "~1.9.1"
 
-"jsesc@^1.3.0":
-  "integrity" "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-  "resolved" "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
-  "version" "1.3.0"
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
+  integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
-"jsesc@^2.5.1":
-  "integrity" "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
-  "resolved" "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
-  "version" "2.5.2"
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-"jsesc@~0.5.0":
-  "integrity" "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-  "resolved" "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-  "version" "0.5.0"
+jsesc@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+  integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-"json-schema@0.2.3":
-  "integrity" "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-  "resolved" "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-  "version" "0.2.3"
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-"json-stable-stringify@^1.0.0", "json-stable-stringify@^1.0.1":
-  "integrity" "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
-  "resolved" "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-  "version" "1.0.1"
+json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
   dependencies:
-    "jsonify" "~0.0.0"
+    jsonify "~0.0.0"
 
-"json-stringify-safe@~5.0.0", "json-stringify-safe@~5.0.1":
-  "integrity" "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-  "resolved" "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-  "version" "5.0.1"
+json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-"json3@3.3.2":
-  "integrity" "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-  "resolved" "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
-  "version" "3.3.2"
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
-"json5@^0.5.1":
-  "integrity" "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-  "resolved" "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-  "version" "0.5.1"
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
-"json5@^2.1.2":
-  "integrity" "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA=="
-  "resolved" "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz"
-  "version" "2.2.0"
+json5@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
-    "minimist" "^1.2.5"
+    minimist "^1.2.5"
 
-"jsonfile@^2.1.0":
-  "integrity" "sha1-NzaitCi4e72gzIO1P6PWM6NcKug="
-  "resolved" "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
-  "version" "2.4.0"
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
+  integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
   optionalDependencies:
-    "graceful-fs" "^4.1.6"
+    graceful-fs "^4.1.6"
 
-"jsonify@~0.0.0":
-  "integrity" "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-  "resolved" "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-  "version" "0.0.0"
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-"jsonpointer@^4.0.0":
-  "integrity" "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-  "resolved" "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
-  "version" "4.0.1"
+jsonpointer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
 
-"jsprim@^1.2.2":
-  "integrity" "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI="
-  "resolved" "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
-  "version" "1.4.1"
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
+  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
   dependencies:
-    "assert-plus" "1.0.0"
-    "extsprintf" "1.3.0"
-    "json-schema" "0.2.3"
-    "verror" "1.10.0"
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
 
-"jsx-ast-utils@^1.0.0", "jsx-ast-utils@^1.3.1":
-  "integrity" "sha1-Wv44ho9WvIzHrq7wEAuox1vRJZE="
-  "resolved" "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz"
-  "version" "1.4.0"
+jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz"
+  integrity sha1-Wv44ho9WvIzHrq7wEAuox1vRJZE=
   dependencies:
-    "object-assign" "^4.1.0"
+    object-assign "^4.1.0"
 
-"kind-of@^3.0.2", "kind-of@^3.0.3", "kind-of@^3.2.0":
-  "integrity" "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
-  "resolved" "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-  "version" "3.2.2"
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
   dependencies:
-    "is-buffer" "^1.1.5"
+    is-buffer "^1.1.5"
 
-"kind-of@^4.0.0":
-  "integrity" "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
-  "resolved" "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
-  "version" "4.0.0"
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
-    "is-buffer" "^1.1.5"
+    is-buffer "^1.1.5"
 
-"kind-of@^5.0.0":
-  "integrity" "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-  "resolved" "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz"
-  "version" "5.1.0"
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
-"kind-of@^6.0.0":
-  "integrity" "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-  "resolved" "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
-  "version" "6.0.2"
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-"kind-of@^6.0.2":
-  "integrity" "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-  "resolved" "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
-  "version" "6.0.2"
-
-"klaw@^1.0.0":
-  "integrity" "sha1-QIhDO0azsbolnXh4XY6W9zugJDk="
-  "resolved" "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
-  "version" "1.3.1"
+klaw@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
+  integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
   optionalDependencies:
-    "graceful-fs" "^4.1.9"
+    graceful-fs "^4.1.9"
 
-"klaw@^3.0.0":
-  "integrity" "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g=="
-  "resolved" "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz"
-  "version" "3.0.0"
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
   dependencies:
-    "graceful-fs" "^4.1.9"
+    graceful-fs "^4.1.9"
 
-"lazy-cache@^2.0.1":
-  "integrity" "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ="
-  "resolved" "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
-  "version" "2.0.2"
+lazy-cache@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+  integrity sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
   dependencies:
-    "set-getter" "^0.1.0"
+    set-getter "^0.1.0"
 
-"lazystream@^1.0.0":
-  "integrity" "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ="
-  "resolved" "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
-  "version" "1.0.0"
+lazystream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
+  integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
   dependencies:
-    "readable-stream" "^2.0.5"
+    readable-stream "^2.0.5"
 
-"level-blobs@^0.1.7":
-  "integrity" "sha1-mrm5e7mfHtv594o0M+Ie1WOGva8="
-  "resolved" "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz"
-  "version" "0.1.7"
+level-blobs@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz"
+  integrity sha1-mrm5e7mfHtv594o0M+Ie1WOGva8=
   dependencies:
-    "level-peek" "1.0.6"
-    "once" "^1.3.0"
-    "readable-stream" "^1.0.26-4"
+    level-peek "1.0.6"
+    once "^1.3.0"
+    readable-stream "^1.0.26-4"
 
-"level-filesystem@^1.0.1":
-  "integrity" "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M="
-  "resolved" "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz"
-  "version" "1.2.0"
+level-filesystem@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz"
+  integrity sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M=
   dependencies:
-    "concat-stream" "^1.4.4"
-    "errno" "^0.1.1"
-    "fwd-stream" "^1.0.4"
-    "level-blobs" "^0.1.7"
-    "level-peek" "^1.0.6"
-    "level-sublevel" "^5.2.0"
-    "octal" "^1.0.0"
-    "once" "^1.3.0"
-    "xtend" "^2.2.0"
+    concat-stream "^1.4.4"
+    errno "^0.1.1"
+    fwd-stream "^1.0.4"
+    level-blobs "^0.1.7"
+    level-peek "^1.0.6"
+    level-sublevel "^5.2.0"
+    octal "^1.0.0"
+    once "^1.3.0"
+    xtend "^2.2.0"
 
-"level-fix-range@~1.0.2":
-  "integrity" "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg="
-  "resolved" "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz"
-  "version" "1.0.2"
-
-"level-fix-range@2.0":
-  "integrity" "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug="
-  "resolved" "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz"
-  "version" "2.0.0"
+level-fix-range@2.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz"
+  integrity sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug=
   dependencies:
-    "clone" "~0.1.9"
+    clone "~0.1.9"
+
+level-fix-range@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz"
+  integrity sha1-vxW5Fa422EcMgh6IPd95zRZCCCg=
 
 "level-hooks@>=4.4.0 <5":
-  "integrity" "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM="
-  "resolved" "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz"
-  "version" "4.5.0"
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz"
+  integrity sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM=
   dependencies:
-    "string-range" "~1.2"
+    string-range "~1.2"
 
-"level-js@^2.1.3":
-  "integrity" "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc="
-  "resolved" "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz"
-  "version" "2.2.4"
+level-js@^2.1.3:
+  version "2.2.4"
+  resolved "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz"
+  integrity sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=
   dependencies:
-    "abstract-leveldown" "~0.12.0"
-    "idb-wrapper" "^1.5.0"
-    "isbuffer" "~0.0.0"
-    "ltgt" "^2.1.2"
-    "typedarray-to-buffer" "~1.0.0"
-    "xtend" "~2.1.2"
+    abstract-leveldown "~0.12.0"
+    idb-wrapper "^1.5.0"
+    isbuffer "~0.0.0"
+    ltgt "^2.1.2"
+    typedarray-to-buffer "~1.0.0"
+    xtend "~2.1.2"
 
-"level-peek@^1.0.6", "level-peek@1.0.6":
-  "integrity" "sha1-vsUccqgu5GTTNkNMfIdsP8vM538="
-  "resolved" "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz"
-  "version" "1.0.6"
+level-peek@1.0.6, level-peek@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz"
+  integrity sha1-vsUccqgu5GTTNkNMfIdsP8vM538=
   dependencies:
-    "level-fix-range" "~1.0.2"
+    level-fix-range "~1.0.2"
 
-"level-sublevel@^5.2.0":
-  "integrity" "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo="
-  "resolved" "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz"
-  "version" "5.2.3"
+level-sublevel@^5.2.0:
+  version "5.2.3"
+  resolved "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz"
+  integrity sha1-dEwSxy0ucr543eO5tc2E1iGRQTo=
   dependencies:
-    "level-fix-range" "2.0"
-    "level-hooks" ">=4.4.0 <5"
-    "string-range" "~1.2.1"
-    "xtend" "~2.0.4"
+    level-fix-range "2.0"
+    level-hooks ">=4.4.0 <5"
+    string-range "~1.2.1"
+    xtend "~2.0.4"
 
-"levelup@^0.18.2":
-  "integrity" "sha1-5qAcsIlhbI7MApHCqb0/DETj5es="
-  "resolved" "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz"
-  "version" "0.18.6"
+levelup@^0.18.2:
+  version "0.18.6"
+  resolved "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz"
+  integrity sha1-5qAcsIlhbI7MApHCqb0/DETj5es=
   dependencies:
-    "bl" "~0.8.1"
-    "deferred-leveldown" "~0.2.0"
-    "errno" "~0.1.1"
-    "prr" "~0.0.0"
-    "readable-stream" "~1.0.26"
-    "semver" "~2.3.1"
-    "xtend" "~3.0.0"
+    bl "~0.8.1"
+    deferred-leveldown "~0.2.0"
+    errno "~0.1.1"
+    prr "~0.0.0"
+    readable-stream "~1.0.26"
+    semver "~2.3.1"
+    xtend "~3.0.0"
 
-"levn@^0.3.0", "levn@~0.3.0":
-  "integrity" "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4="
-  "resolved" "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-  "version" "0.3.0"
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   dependencies:
-    "prelude-ls" "~1.1.2"
-    "type-check" "~0.3.2"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
-"linkify-it@^2.0.0":
-  "integrity" "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw=="
-  "resolved" "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz"
-  "version" "2.2.0"
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
   dependencies:
-    "uc.micro" "^1.0.1"
+    uc.micro "^1.0.1"
 
-"livereload-js@^2.2.2":
-  "integrity" "sha1-bIclfmSKtHW8JOoldFftzB+NC8I="
-  "resolved" "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
-  "version" "2.2.2"
+livereload-js@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
+  integrity sha1-bIclfmSKtHW8JOoldFftzB+NC8I=
 
-"lodash._baseassign@^3.0.0":
-  "integrity" "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4="
-  "resolved" "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
-  "version" "3.2.0"
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+  integrity sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=
   dependencies:
-    "lodash._basecopy" "^3.0.0"
-    "lodash.keys" "^3.0.0"
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
 
-"lodash._basecopy@^3.0.0":
-  "integrity" "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-  "resolved" "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-  "version" "3.0.1"
+lodash._basecopy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+  integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
 
-"lodash._basecreate@^3.0.0":
-  "integrity" "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
-  "resolved" "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
-  "version" "3.0.3"
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+  integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
 
-"lodash._basetostring@^3.0.0":
-  "integrity" "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-  "resolved" "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-  "version" "3.0.1"
+lodash._basetostring@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+  integrity sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=
 
-"lodash._basevalues@^3.0.0":
-  "integrity" "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-  "resolved" "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-  "version" "3.0.0"
+lodash._basevalues@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+  integrity sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=
 
-"lodash._getnative@^3.0.0":
-  "integrity" "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-  "resolved" "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-  "version" "3.9.1"
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
-"lodash._isiterateecall@^3.0.0":
-  "integrity" "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-  "resolved" "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-  "version" "3.0.9"
+lodash._isiterateecall@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+  integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
 
-"lodash._reescape@^3.0.0":
-  "integrity" "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-  "resolved" "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-  "version" "3.0.0"
+lodash._reescape@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+  integrity sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=
 
-"lodash._reevaluate@^3.0.0":
-  "integrity" "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-  "resolved" "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-  "version" "3.0.0"
+lodash._reevaluate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+  integrity sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=
 
-"lodash._reinterpolate@^3.0.0":
-  "integrity" "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-  "resolved" "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-  "version" "3.0.0"
+lodash._reinterpolate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-"lodash._root@^3.0.0":
-  "integrity" "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-  "resolved" "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-  "version" "3.0.1"
+lodash._root@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+  integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
 
-"lodash.assign@^4.0.0":
-  "integrity" "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-  "resolved" "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
-  "version" "4.2.0"
+lodash.assign@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
 
-"lodash.camelcase@^4.3.0":
-  "integrity" "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-  "resolved" "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz"
-  "version" "4.3.0"
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-"lodash.cond@^4.3.0":
-  "integrity" "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
-  "resolved" "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz"
-  "version" "4.5.2"
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz"
+  integrity sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=
 
-"lodash.create@3.1.1":
-  "integrity" "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c="
-  "resolved" "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz"
-  "version" "3.1.1"
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz"
+  integrity sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=
   dependencies:
-    "lodash._baseassign" "^3.0.0"
-    "lodash._basecreate" "^3.0.0"
-    "lodash._isiterateecall" "^3.0.0"
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
 
-"lodash.endswith@^4.0.1":
-  "integrity" "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk="
-  "resolved" "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz"
-  "version" "4.2.1"
+lodash.endswith@^4.0.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz"
+  integrity sha1-/tWawXOO0+I27dcGTsRWRIs3vAk=
 
-"lodash.escape@^3.0.0":
-  "integrity" "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg="
-  "resolved" "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
-  "version" "3.2.0"
+lodash.escape@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+  integrity sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=
   dependencies:
-    "lodash._root" "^3.0.0"
+    lodash._root "^3.0.0"
 
-"lodash.find@^4.3.0":
-  "integrity" "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-  "resolved" "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz"
-  "version" "4.6.0"
+lodash.find@^4.3.0:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz"
+  integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
 
-"lodash.findindex@^4.3.0":
-  "integrity" "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
-  "resolved" "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz"
-  "version" "4.6.0"
+lodash.findindex@^4.3.0:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz"
+  integrity sha1-oyRd7mH7m24GJLU1ElYku2nBEQY=
 
-"lodash.foreach@^4.5.0":
-  "integrity" "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-  "resolved" "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz"
-  "version" "4.5.0"
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz"
+  integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
-"lodash.isarguments@^3.0.0":
-  "integrity" "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-  "resolved" "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
-  "version" "3.1.0"
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
 
-"lodash.isarray@^3.0.0":
-  "integrity" "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-  "resolved" "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-  "version" "3.0.4"
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
-"lodash.isequal@^4.0.0":
-  "integrity" "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-  "resolved" "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
-  "version" "4.5.0"
+lodash.isequal@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
-"lodash.kebabcase@4.1.1":
-  "integrity" "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
-  "resolved" "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz"
-  "version" "4.1.1"
+lodash.kebabcase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
-"lodash.keys@^3.0.0":
-  "integrity" "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
-  "resolved" "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-  "version" "3.1.2"
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+  integrity sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
   dependencies:
-    "lodash._getnative" "^3.0.0"
-    "lodash.isarguments" "^3.0.0"
-    "lodash.isarray" "^3.0.0"
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
-"lodash.omit@^4.5.0":
-  "integrity" "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-  "resolved" "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz"
-  "version" "4.5.0"
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
-"lodash.padend@^4.6.1":
-  "integrity" "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
-  "resolved" "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz"
-  "version" "4.6.1"
+lodash.padend@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz"
+  integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
 
-"lodash.pick@^4.4.0":
-  "integrity" "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-  "resolved" "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
-  "version" "4.4.0"
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
-"lodash.pickby@^4.0.0":
-  "integrity" "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
-  "resolved" "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz"
-  "version" "4.6.0"
+lodash.pickby@^4.0.0:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz"
+  integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
 
-"lodash.restparam@^3.0.0":
-  "integrity" "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-  "resolved" "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-  "version" "3.6.1"
+lodash.restparam@^3.0.0:
+  version "3.6.1"
+  resolved "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
-"lodash.sumby@^4.6.0":
-  "integrity" "sha1-fYdzfdshbaL35efNLdnEA6eIc0Y="
-  "resolved" "https://registry.npmjs.org/lodash.sumby/-/lodash.sumby-4.6.0.tgz"
-  "version" "4.6.0"
+lodash.sumby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/lodash.sumby/-/lodash.sumby-4.6.0.tgz"
+  integrity sha1-fYdzfdshbaL35efNLdnEA6eIc0Y=
 
-"lodash.template@^3.0.0":
-  "integrity" "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8="
-  "resolved" "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
-  "version" "3.6.2"
+lodash.template@^3.0.0:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
+  integrity sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=
   dependencies:
-    "lodash._basecopy" "^3.0.0"
-    "lodash._basetostring" "^3.0.0"
-    "lodash._basevalues" "^3.0.0"
-    "lodash._isiterateecall" "^3.0.0"
-    "lodash._reinterpolate" "^3.0.0"
-    "lodash.escape" "^3.0.0"
-    "lodash.keys" "^3.0.0"
-    "lodash.restparam" "^3.0.0"
-    "lodash.templatesettings" "^3.0.0"
+    lodash._basecopy "^3.0.0"
+    lodash._basetostring "^3.0.0"
+    lodash._basevalues "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+    lodash._reinterpolate "^3.0.0"
+    lodash.escape "^3.0.0"
+    lodash.keys "^3.0.0"
+    lodash.restparam "^3.0.0"
+    lodash.templatesettings "^3.0.0"
 
-"lodash.templatesettings@^3.0.0":
-  "integrity" "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU="
-  "resolved" "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
-  "version" "3.1.1"
+lodash.templatesettings@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+  integrity sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=
   dependencies:
-    "lodash._reinterpolate" "^3.0.0"
-    "lodash.escape" "^3.0.0"
+    lodash._reinterpolate "^3.0.0"
+    lodash.escape "^3.0.0"
 
-"lodash@^4.0.0", "lodash@^4.0.1", "lodash@^4.13.1", "lodash@^4.17.4", "lodash@^4.2.0", "lodash@^4.3.0", "lodash@^4.5.1", "lodash@^4.9.0":
-  "integrity" "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-  "resolved" "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-  "version" "4.17.4"
+lodash@3.9.3:
+  version "3.9.3"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+  integrity sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=
 
-"lodash@^4.17.11":
-  "integrity" "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-  "resolved" "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  "version" "4.17.21"
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.9.0:
+  version "4.17.4"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
 
-"lodash@^4.17.14":
-  "integrity" "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-  "resolved" "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz"
-  "version" "4.17.15"
+lodash@^4.17.11:
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-"lodash@3.9.3":
-  "integrity" "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI="
-  "resolved" "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-  "version" "3.9.3"
+lodash@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-"loose-envify@^1.0.0":
-  "integrity" "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
-  "resolved" "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
-  "version" "1.3.1"
+loose-envify@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+  integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   dependencies:
-    "js-tokens" "^3.0.0"
+    js-tokens "^3.0.0"
 
-"lowercase-keys@^1.0.0":
-  "integrity" "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-  "resolved" "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
-  "version" "1.0.0"
+lowercase-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+  integrity sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=
 
-"ltgt@^2.1.2":
-  "integrity" "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
-  "resolved" "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz"
-  "version" "2.2.0"
+ltgt@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz"
+  integrity sha1-tlul/LNJopkkyOMz98alVi8uSEI=
 
-"magic-string@^0.16.0":
-  "integrity" "sha1-lw67DacZMwEoX7GqZQ85vdgetFo="
-  "resolved" "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz"
-  "version" "0.16.0"
+magic-string@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz"
+  integrity sha1-lw67DacZMwEoX7GqZQ85vdgetFo=
   dependencies:
-    "vlq" "^0.2.1"
+    vlq "^0.2.1"
 
-"magic-string@^0.19.0":
-  "integrity" "sha1-FNdoATyvLsj96hakmvgvw3fnUgE="
-  "resolved" "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz"
-  "version" "0.19.1"
+magic-string@^0.19.0:
+  version "0.19.1"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz"
+  integrity sha1-FNdoATyvLsj96hakmvgvw3fnUgE=
   dependencies:
-    "vlq" "^0.2.1"
+    vlq "^0.2.1"
 
-"make-dir@^1.0.0":
-  "integrity" "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg="
-  "resolved" "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz"
-  "version" "1.0.0"
+make-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz"
+  integrity sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=
   dependencies:
-    "pify" "^2.3.0"
+    pify "^2.3.0"
 
-"map-cache@^0.2.2":
-  "integrity" "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-  "resolved" "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
-  "version" "0.2.2"
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
+  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
-"map-visit@^1.0.0":
-  "integrity" "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48="
-  "resolved" "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
-  "version" "1.0.0"
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
+  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
-    "object-visit" "^1.0.0"
+    object-visit "^1.0.0"
 
-"markdown-it-anchor@^5.0.2":
-  "integrity" "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A=="
-  "resolved" "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz"
-  "version" "5.2.4"
+markdown-it-anchor@^5.0.2:
+  version "5.2.4"
+  resolved "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz"
+  integrity sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==
 
-"markdown-it@*", "markdown-it@^8.4.2":
-  "integrity" "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ=="
-  "resolved" "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz"
-  "version" "8.4.2"
+markdown-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz"
+  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
   dependencies:
-    "argparse" "^1.0.7"
-    "entities" "~1.1.1"
-    "linkify-it" "^2.0.0"
-    "mdurl" "^1.0.1"
-    "uc.micro" "^1.0.5"
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
 
-"marked@^0.7.0":
-  "integrity" "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-  "resolved" "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz"
-  "version" "0.7.0"
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
-"matched@^0.4.3":
-  "integrity" "sha1-Vte36xgDPwz5vFLrIJD6x9weifo="
-  "resolved" "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz"
-  "version" "0.4.4"
+matched@^0.4.3:
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz"
+  integrity sha1-Vte36xgDPwz5vFLrIJD6x9weifo=
   dependencies:
-    "arr-union" "^3.1.0"
-    "async-array-reduce" "^0.2.0"
-    "extend-shallow" "^2.0.1"
-    "fs-exists-sync" "^0.1.0"
-    "glob" "^7.0.5"
-    "has-glob" "^0.1.1"
-    "is-valid-glob" "^0.3.0"
-    "lazy-cache" "^2.0.1"
-    "resolve-dir" "^0.1.0"
+    arr-union "^3.1.0"
+    async-array-reduce "^0.2.0"
+    extend-shallow "^2.0.1"
+    fs-exists-sync "^0.1.0"
+    glob "^7.0.5"
+    has-glob "^0.1.1"
+    is-valid-glob "^0.3.0"
+    lazy-cache "^2.0.1"
+    resolve-dir "^0.1.0"
 
-"math-random@^1.0.1":
-  "integrity" "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
-  "resolved" "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz"
-  "version" "1.0.1"
+math-random@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz"
+  integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
-"mdurl@^1.0.1":
-  "integrity" "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
-  "resolved" "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
-  "version" "1.0.1"
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
-"merge-stream@^1.0.0":
-  "integrity" "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE="
-  "resolved" "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz"
-  "version" "1.0.1"
+merge-stream@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz"
+  integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
   dependencies:
-    "readable-stream" "^2.0.1"
+    readable-stream "^2.0.1"
 
-"merge@1.x":
-  "integrity" "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
-  "resolved" "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
-  "version" "1.2.0"
+merge@1.x:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+  integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
 
-"micromatch@^2.1.5", "micromatch@^2.3.11", "micromatch@^2.3.7":
-  "integrity" "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
-  "resolved" "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-  "version" "2.3.11"
+micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
+  version "2.3.11"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+  integrity sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=
   dependencies:
-    "arr-diff" "^2.0.0"
-    "array-unique" "^0.2.1"
-    "braces" "^1.8.2"
-    "expand-brackets" "^0.1.4"
-    "extglob" "^0.3.1"
-    "filename-regex" "^2.0.0"
-    "is-extglob" "^1.0.0"
-    "is-glob" "^2.0.1"
-    "kind-of" "^3.0.2"
-    "normalize-path" "^2.0.1"
-    "object.omit" "^2.0.0"
-    "parse-glob" "^3.0.4"
-    "regex-cache" "^0.4.2"
+    arr-diff "^2.0.0"
+    array-unique "^0.2.1"
+    braces "^1.8.2"
+    expand-brackets "^0.1.4"
+    extglob "^0.3.1"
+    filename-regex "^2.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.1"
+    kind-of "^3.0.2"
+    normalize-path "^2.0.1"
+    object.omit "^2.0.0"
+    parse-glob "^3.0.4"
+    regex-cache "^0.4.2"
 
-"micromatch@^3.1.10":
-  "integrity" "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg=="
-  "resolved" "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz"
-  "version" "3.1.10"
+micromatch@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz"
+  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
   dependencies:
-    "arr-diff" "^4.0.0"
-    "array-unique" "^0.3.2"
-    "braces" "^2.3.1"
-    "define-property" "^2.0.2"
-    "extend-shallow" "^3.0.2"
-    "extglob" "^2.0.4"
-    "fragment-cache" "^0.2.1"
-    "kind-of" "^6.0.2"
-    "nanomatch" "^1.2.9"
-    "object.pick" "^1.3.0"
-    "regex-not" "^1.0.0"
-    "snapdragon" "^0.8.1"
-    "to-regex" "^3.0.2"
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
 
-"miller-rabin@^4.0.0":
-  "integrity" "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0="
-  "resolved" "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
-  "version" "4.0.0"
+miller-rabin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
+  integrity sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=
   dependencies:
-    "bn.js" "^4.0.0"
-    "brorand" "^1.0.1"
+    bn.js "^4.0.0"
+    brorand "^1.0.1"
 
-"mime-db@^1.28.0":
-  "integrity" "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
-  "resolved" "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-  "version" "1.29.0"
+mime-db@^1.28.0:
+  version "1.29.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+  integrity sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=
 
-"mime-db@~1.12.0":
-  "integrity" "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
-  "resolved" "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-  "version" "1.12.0"
+mime-db@~1.12.0:
+  version "1.12.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+  integrity sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=
 
-"mime-db@~1.30.0":
-  "integrity" "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-  "resolved" "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
-  "version" "1.30.0"
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+  integrity sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=
 
-"mime-db@~1.37.0":
-  "integrity" "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
-  "resolved" "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz"
-  "version" "1.37.0"
+mime-db@~1.37.0:
+  version "1.37.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz"
+  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
 
-"mime-types@^2.1.12", "mime-types@~2.1.7":
-  "integrity" "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg=="
-  "resolved" "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz"
-  "version" "2.1.21"
+mime-types@2.1.17:
+  version "2.1.17"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
+  integrity sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=
   dependencies:
-    "mime-db" "~1.37.0"
+    mime-db "~1.30.0"
 
-"mime-types@~1.0.1":
-  "integrity" "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
-  "resolved" "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-  "version" "1.0.2"
-
-"mime-types@~2.0.3":
-  "integrity" "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY="
-  "resolved" "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
-  "version" "2.0.14"
+mime-types@^2.1.12, mime-types@~2.1.7:
+  version "2.1.21"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz"
+  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
   dependencies:
-    "mime-db" "~1.12.0"
+    mime-db "~1.37.0"
 
-"mime-types@2.1.17":
-  "integrity" "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
-  "resolved" "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
-  "version" "2.1.17"
+mime-types@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+  integrity sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=
+
+mime-types@~2.0.3:
+  version "2.0.14"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+  integrity sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=
   dependencies:
-    "mime-db" "~1.30.0"
+    mime-db "~1.12.0"
 
-"mime@^1.2.11":
-  "integrity" "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
-  "resolved" "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-  "version" "1.3.4"
+mime@^1.2.11:
+  version "1.3.4"
+  resolved "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+  integrity sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=
 
-"mimic-response@^1.0.0":
-  "integrity" "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
-  "resolved" "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz"
-  "version" "1.0.0"
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz"
+  integrity sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=
 
-"minimalistic-assert@^1.0.0":
-  "integrity" "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
-  "resolved" "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-  "version" "1.0.0"
+minimalistic-assert@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+  integrity sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=
 
-"minimalistic-crypto-utils@^1.0.0", "minimalistic-crypto-utils@^1.0.1":
-  "integrity" "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-  "resolved" "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
-  "version" "1.0.1"
-
-"minimatch@^3.0.0", "minimatch@^3.0.2", "minimatch@^3.0.4":
-  "integrity" "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
-  "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-  "version" "3.0.4"
-  dependencies:
-    "brace-expansion" "^1.1.7"
+minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 "minimatch@2 || 3":
-  "integrity" "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
-  "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-  "version" "3.0.3"
-  dependencies:
-    "brace-expansion" "^1.0.0"
-
-"minimist@^1.1.0":
-  "integrity" "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-  "resolved" "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
-  "version" "1.2.8"
-
-"minimist@^1.2.0":
-  "integrity" "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-  "resolved" "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
-  "version" "1.2.8"
-
-"minimist@^1.2.5":
-  "integrity" "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-  "resolved" "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
-  "version" "1.2.8"
-
-"minimist@~0.0.1":
-  "integrity" "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-  "resolved" "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-  "version" "0.0.8"
-
-"minimist@0.0.8":
-  "integrity" "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-  "resolved" "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-  "version" "0.0.8"
-
-"minimist@1.1.0":
-  "integrity" "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM="
-  "resolved" "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
-  "version" "1.1.0"
-
-"minimist@1.2.0":
-  "integrity" "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-  "resolved" "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-  "version" "1.2.0"
-
-"mixin-deep@^1.2.0":
-  "integrity" "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ=="
-  "resolved" "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz"
-  "version" "1.3.1"
-  dependencies:
-    "for-in" "^1.0.2"
-    "is-extendable" "^1.0.1"
-
-"mkdirp@^0.5.0", "mkdirp@^0.5.1", "mkdirp@0.5.1", "mkdirp@0.5.x":
-  "integrity" "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
-  "resolved" "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-  "version" "0.5.1"
-  dependencies:
-    "minimist" "0.0.8"
-
-"mkdirp@0.5.0":
-  "integrity" "sha1-HXMHam35hs2TROFecfzAWkyavxI="
-  "resolved" "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz"
-  "version" "0.5.0"
-  dependencies:
-    "minimist" "0.0.8"
-
-"mkdirp2@^1.0.3":
-  "integrity" "sha1-zI3YJl8fBuLY9bELblL04FC+0hs="
-  "resolved" "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz"
-  "version" "1.0.3"
-
-"mocha@3.5.0":
-  "integrity" "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA=="
-  "resolved" "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz"
-  "version" "3.5.0"
-  dependencies:
-    "browser-stdout" "1.3.0"
-    "commander" "2.9.0"
-    "debug" "2.6.8"
-    "diff" "3.2.0"
-    "escape-string-regexp" "1.0.5"
-    "glob" "7.1.1"
-    "growl" "1.9.2"
-    "json3" "3.3.2"
-    "lodash.create" "3.1.1"
-    "mkdirp" "0.5.1"
-    "supports-color" "3.1.2"
-
-"module-details-from-path@^1.0.3":
-  "integrity" "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
-  "resolved" "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz"
-  "version" "1.0.3"
-
-"moment@2.x.x":
-  "integrity" "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-  "resolved" "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
-  "version" "2.18.1"
-
-"ms@0.7.2":
-  "integrity" "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-  "resolved" "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-  "version" "0.7.2"
-
-"ms@2.0.0":
-  "integrity" "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-  "resolved" "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-  "version" "2.0.0"
-
-"ms@2.1.2":
-  "integrity" "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-  "resolved" "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  "version" "2.1.2"
-
-"multimatch@^2.1.0":
-  "integrity" "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis="
-  "resolved" "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz"
-  "version" "2.1.0"
-  dependencies:
-    "array-differ" "^1.0.0"
-    "array-union" "^1.0.1"
-    "arrify" "^1.0.0"
-    "minimatch" "^3.0.0"
-
-"multipipe@^0.1.2":
-  "integrity" "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s="
-  "resolved" "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
-  "version" "0.1.2"
-  dependencies:
-    "duplexer2" "0.0.2"
-
-"mute-stream@0.0.5":
-  "integrity" "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-  "resolved" "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-  "version" "0.0.5"
-
-"nanomatch@^1.2.9":
-  "integrity" "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA=="
-  "resolved" "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz"
-  "version" "1.2.13"
-  dependencies:
-    "arr-diff" "^4.0.0"
-    "array-unique" "^0.3.2"
-    "define-property" "^2.0.2"
-    "extend-shallow" "^3.0.2"
-    "fragment-cache" "^0.2.1"
-    "is-windows" "^1.0.2"
-    "kind-of" "^6.0.2"
-    "object.pick" "^1.3.0"
-    "regex-not" "^1.0.0"
-    "snapdragon" "^0.8.1"
-    "to-regex" "^3.0.1"
-
-"natural-compare@^1.4.0":
-  "integrity" "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-  "resolved" "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
-  "version" "1.4.0"
-
-"neo-async@^2.6.0":
-  "integrity" "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-  "resolved" "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
-  "version" "2.6.2"
-
-"node-fetch@^1.3.3":
-  "integrity" "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ="
-  "resolved" "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
-  "version" "1.6.3"
-  dependencies:
-    "encoding" "^0.1.11"
-    "is-stream" "^1.0.1"
-
-"node-fetch@1.6.3":
-  "integrity" "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ="
-  "resolved" "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
-  "version" "1.6.3"
-  dependencies:
-    "encoding" "^0.1.11"
-    "is-stream" "^1.0.1"
-
-"node-fetch@1.7.2":
-  "integrity" "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig=="
-  "resolved" "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz"
-  "version" "1.7.2"
-  dependencies:
-    "encoding" "^0.1.11"
-    "is-stream" "^1.0.1"
-
-"node-jq@0.7.0":
-  "integrity" "sha512-5oMKLqc1KF+1K8cm84NyDP8ZBT2lo8H7tDC7Xiywj295ukEmE9Wo8XDIKz/ehmJAcVwAPWFg40pLfuZjWJmcfg=="
-  "resolved" "https://registry.npmjs.org/node-jq/-/node-jq-0.7.0.tgz"
-  "version" "0.7.0"
-  dependencies:
-    "bin-build" "^2.2.0"
-    "download" "^6.0.0"
-    "is-valid-path" "^0.1.1"
-    "strip-eof" "^1.0.0"
-    "tempfile" "^2.0.0"
-
-"node-releases@^1.1.75":
-  "integrity" "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
-  "resolved" "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz"
-  "version" "1.1.75"
-
-"node-status-codes@^1.0.0":
-  "integrity" "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
-  "resolved" "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
-  "version" "1.0.0"
-
-"node-uuid@~1.4.0":
-  "integrity" "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-  "resolved" "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
-  "version" "1.4.8"
-
-"normalize-path@^2.0.0", "normalize-path@^2.0.1":
-  "integrity" "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
-  "resolved" "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
-  "version" "2.1.1"
-  dependencies:
-    "remove-trailing-separator" "^1.0.1"
-
-"npm-conf@^1.1.0":
-  "integrity" "sha512-dotwbpwVzfNB/2EF3A2wjK5tEMLggKfuA/8TG6WvBB1Zrv+JsvF7E8ei9B/HGq211st/GwXFbREcNJvJ1eySUQ=="
-  "resolved" "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.2.tgz"
-  "version" "1.1.2"
-  dependencies:
-    "config-chain" "^1.1.11"
-    "pify" "^3.0.0"
-
-"number-is-nan@^1.0.0":
-  "integrity" "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-  "resolved" "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-  "version" "1.0.1"
-
-"oauth-sign@~0.5.0":
-  "integrity" "sha1-12f1FpMlYg6rLgh+8MRy53PbZGE="
-  "resolved" "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-  "version" "0.5.0"
-
-"oauth-sign@~0.8.1":
-  "integrity" "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-  "resolved" "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-  "version" "0.8.2"
-
-"object-assign@^2.0.0":
-  "integrity" "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-  "resolved" "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-  "version" "2.1.1"
-
-"object-assign@^3.0.0":
-  "integrity" "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-  "resolved" "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-  "version" "3.0.0"
-
-"object-assign@^4.0.0", "object-assign@^4.0.1", "object-assign@^4.1.0":
-  "integrity" "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-  "resolved" "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-  "version" "4.1.1"
-
-"object-copy@^0.1.0":
-  "integrity" "sha1-fn2Fi3gb18mRpBupde04EnVOmYw="
-  "resolved" "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz"
-  "version" "0.1.0"
-  dependencies:
-    "copy-descriptor" "^0.1.0"
-    "define-property" "^0.2.5"
-    "kind-of" "^3.0.3"
-
-"object-get@^2.1.0":
-  "integrity" "sha1-ciu9tgA576R8rTxtws5RqFwCxa4="
-  "resolved" "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz"
-  "version" "2.1.0"
-
-"object-keys@^1.0.8":
-  "integrity" "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
-  "resolved" "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-  "version" "1.0.11"
-
-"object-keys@~0.2.0":
-  "integrity" "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc="
-  "resolved" "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz"
-  "version" "0.2.0"
-  dependencies:
-    "foreach" "~2.0.1"
-    "indexof" "~0.0.1"
-    "is" "~0.2.6"
-
-"object-keys@~0.4.0":
-  "integrity" "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-  "resolved" "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-  "version" "0.4.0"
-
-"object-to-spawn-args@^1.1.1":
-  "integrity" "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U="
-  "resolved" "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz"
-  "version" "1.1.1"
-
-"object-visit@^1.0.0":
-  "integrity" "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs="
-  "resolved" "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
-  "version" "1.0.1"
-  dependencies:
-    "isobject" "^3.0.0"
-
-"object.getownpropertydescriptors@^2.0.3":
-  "integrity" "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY="
-  "resolved" "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz"
-  "version" "2.0.3"
-  dependencies:
-    "define-properties" "^1.1.2"
-    "es-abstract" "^1.5.1"
-
-"object.omit@^2.0.0":
-  "integrity" "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo="
-  "resolved" "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "for-own" "^0.1.4"
-    "is-extendable" "^0.1.1"
-
-"object.pick@^1.3.0":
-  "integrity" "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c="
-  "resolved" "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz"
-  "version" "1.3.0"
-  dependencies:
-    "isobject" "^3.0.1"
-
-"octal@^1.0.0":
-  "integrity" "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws="
-  "resolved" "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz"
-  "version" "1.0.0"
-
-"once@^1.3.0", "once@^1.4.0":
-  "integrity" "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
-  "resolved" "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-  "version" "1.4.0"
-  dependencies:
-    "wrappy" "1"
-
-"once@~1.3.0":
-  "integrity" "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
-  "resolved" "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-  "version" "1.3.3"
-  dependencies:
-    "wrappy" "1"
-
-"onetime@^1.0.0":
-  "integrity" "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-  "resolved" "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-  "version" "1.1.0"
-
-"opener@~1.4.0":
-  "integrity" "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
-  "resolved" "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
-  "version" "1.4.3"
-
-"optimist@0.6.x":
-  "integrity" "sha1-2j6nRob6IaGaERwybpDrFaAZZoY="
-  "resolved" "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
-  "version" "0.6.1"
-  dependencies:
-    "minimist" "~0.0.1"
-    "wordwrap" "~0.0.2"
-
-"optionator@^0.8.1", "optionator@^0.8.2":
-  "integrity" "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q="
-  "resolved" "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
-  "version" "0.8.2"
-  dependencies:
-    "deep-is" "~0.1.3"
-    "fast-levenshtein" "~2.0.4"
-    "levn" "~0.3.0"
-    "prelude-ls" "~1.1.2"
-    "type-check" "~0.3.2"
-    "wordwrap" "~1.0.0"
-
-"ordered-read-streams@^0.3.0":
-  "integrity" "sha1-cTfmmzKYuzQiR6G77jiByA4v14s="
-  "resolved" "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
-  "version" "0.3.0"
-  dependencies:
-    "is-stream" "^1.0.1"
-    "readable-stream" "^2.0.1"
-
-"os-homedir@^1.0.0", "os-homedir@^1.0.1":
-  "integrity" "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-  "resolved" "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-  "version" "1.0.2"
-
-"os-tmpdir@^1.0.0", "os-tmpdir@^1.0.1", "os-tmpdir@~1.0.1":
-  "integrity" "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-  "resolved" "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-  "version" "1.0.2"
-
-"p-cancelable@^0.3.0":
-  "integrity" "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-  "resolved" "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz"
-  "version" "0.3.0"
-
-"p-event@^1.0.0":
-  "integrity" "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU="
-  "resolved" "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz"
-  "version" "1.3.0"
-  dependencies:
-    "p-timeout" "^1.1.1"
-
-"p-finally@^1.0.0":
-  "integrity" "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-  "resolved" "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
-  "version" "1.0.0"
-
-"p-timeout@^1.1.1":
-  "integrity" "sha1-mCD5lDTFgXhotPNICe5SkWYNW2w="
-  "resolved" "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.0.tgz"
-  "version" "1.2.0"
-  dependencies:
-    "p-finally" "^1.0.0"
-
-"parse-asn1@^5.0.0":
-  "integrity" "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI="
-  "resolved" "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
-  "version" "5.1.0"
-  dependencies:
-    "asn1.js" "^4.0.0"
-    "browserify-aes" "^1.0.0"
-    "create-hash" "^1.1.0"
-    "evp_bytestokey" "^1.0.0"
-    "pbkdf2" "^3.0.3"
-
-"parse-glob@^3.0.4":
-  "integrity" "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
-  "resolved" "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
-  "version" "3.0.4"
-  dependencies:
-    "glob-base" "^0.3.0"
-    "is-dotfile" "^1.0.0"
-    "is-extglob" "^1.0.0"
-    "is-glob" "^2.0.0"
-
-"parse-json@^2.1.0":
-  "integrity" "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
-  "resolved" "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
-  "version" "2.2.0"
-  dependencies:
-    "error-ex" "^1.2.0"
-
-"parse-passwd@^1.0.0":
-  "integrity" "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-  "resolved" "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
-  "version" "1.0.0"
-
-"pascalcase@^0.1.1":
-  "integrity" "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-  "resolved" "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
-  "version" "0.1.1"
-
-"path-dirname@^1.0.0":
-  "integrity" "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
-  "resolved" "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
-  "version" "1.0.2"
-
-"path-exists@^2.0.0":
-  "integrity" "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
-  "resolved" "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-  "version" "2.1.0"
-  dependencies:
-    "pinkie-promise" "^2.0.0"
-
-"path-is-absolute@^1.0.0", "path-is-absolute@^1.0.1":
-  "integrity" "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-  "resolved" "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-  "version" "1.0.1"
-
-"path-is-inside@^1.0.1":
-  "integrity" "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-  "resolved" "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
-  "version" "1.0.2"
-
-"path-parse@^1.0.5":
-  "integrity" "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-  "resolved" "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-  "version" "1.0.5"
-
-"path-to-regexp@^1.7.0":
-  "integrity" "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30="
-  "resolved" "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz"
-  "version" "1.7.0"
-  dependencies:
-    "isarray" "0.0.1"
-
-"pbkdf2@^3.0.3":
-  "integrity" "sha1-8sSyWmAAWLPDdzwIbDfbvuH/5pM="
-  "resolved" "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
-  "version" "3.0.9"
-  dependencies:
-    "create-hmac" "^1.1.2"
-
-"pend@~1.2.0":
-  "integrity" "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-  "resolved" "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
-  "version" "1.2.0"
-
-"performance-now@^0.2.0":
-  "integrity" "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-  "resolved" "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-  "version" "0.2.0"
-
-"pify@^2.0.0", "pify@^2.3.0":
-  "integrity" "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-  "resolved" "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-  "version" "2.3.0"
-
-"pify@^3.0.0":
-  "integrity" "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-  "resolved" "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
-  "version" "3.0.0"
-
-"pinkie-promise@^2.0.0":
-  "integrity" "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
-  "resolved" "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "pinkie" "^2.0.0"
-
-"pinkie@^2.0.0":
-  "integrity" "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-  "resolved" "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-  "version" "2.0.4"
-
-"pkg-dir@^1.0.0":
-  "integrity" "sha1-ektQio1bstYp1EcFb/TpyTFM89Q="
-  "resolved" "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "find-up" "^1.0.0"
-
-"pkg-up@^1.0.0":
-  "integrity" "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY="
-  "resolved" "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "find-up" "^1.0.0"
-
-"pluralize@^1.2.1":
-  "integrity" "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
-  "resolved" "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
-  "version" "1.2.1"
-
-"portfinder@^1.0.13":
-  "integrity" "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek="
-  "resolved" "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz"
-  "version" "1.0.13"
-  dependencies:
-    "async" "^1.5.2"
-    "debug" "^2.2.0"
-    "mkdirp" "0.5.x"
-
-"posix-character-classes@^0.1.0":
-  "integrity" "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-  "resolved" "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
-  "version" "0.1.1"
-
-"prelude-ls@~1.1.2":
-  "integrity" "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-  "resolved" "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-  "version" "1.1.2"
-
-"prepend-http@^1.0.1":
-  "integrity" "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-  "resolved" "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
-  "version" "1.0.4"
-
-"preserve@^0.2.0":
-  "integrity" "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-  "resolved" "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-  "version" "0.2.0"
-
-"private@^0.1.6", "private@^0.1.7":
-  "integrity" "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
-  "resolved" "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
-  "version" "0.1.7"
-
-"process-es6@^0.11.2", "process-es6@^0.11.3":
-  "integrity" "sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g="
-  "resolved" "https://registry.npmjs.org/process-es6/-/process-es6-0.11.6.tgz"
-  "version" "0.11.6"
-
-"process-nextick-args@~1.0.6":
-  "integrity" "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-  "resolved" "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-  "version" "1.0.7"
-
-"process-nextick-args@~2.0.0":
-  "integrity" "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-  "resolved" "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
-  "version" "2.0.0"
-
-"progress@^1.1.8", "progress@1.1.8":
-  "integrity" "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
-  "resolved" "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
-  "version" "1.1.8"
-
-"proto-list@~1.2.1":
-  "integrity" "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
-  "resolved" "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
-  "version" "1.2.4"
-
-"prr@~0.0.0":
-  "integrity" "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-  "resolved" "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-  "version" "0.0.0"
-
-"public-encrypt@^4.0.0":
-  "integrity" "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY="
-  "resolved" "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "bn.js" "^4.1.0"
-    "browserify-rsa" "^4.0.0"
-    "create-hash" "^1.1.0"
-    "parse-asn1" "^5.0.0"
-    "randombytes" "^2.0.1"
-
-"punycode@^1.4.1":
-  "integrity" "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-  "resolved" "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-  "version" "1.4.1"
-
-"punycode@1.3.2":
-  "integrity" "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-  "resolved" "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-  "version" "1.3.2"
-
-"qs@^6.4.0":
-  "integrity" "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
-  "resolved" "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz"
-  "version" "6.5.0"
-
-"qs@~2.3.1", "qs@~2.3.3":
-  "integrity" "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
-  "resolved" "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-  "version" "2.3.3"
-
-"qs@~6.4.0":
-  "integrity" "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-  "resolved" "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-  "version" "6.4.0"
-
-"querystring@0.2.0":
-  "integrity" "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-  "resolved" "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-  "version" "0.2.0"
-
-"ramda@^0.21.0":
-  "integrity" "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU="
-  "resolved" "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz"
-  "version" "0.21.0"
-
-"randomatic@^3.0.0":
-  "integrity" "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw=="
-  "resolved" "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz"
-  "version" "3.1.1"
-  dependencies:
-    "is-number" "^4.0.0"
-    "kind-of" "^6.0.0"
-    "math-random" "^1.0.1"
-
-"randombytes@^2.0.0", "randombytes@^2.0.1":
-  "integrity" "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew="
-  "resolved" "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
-  "version" "2.0.3"
-
-"raw-body@~1.1.0":
-  "integrity" "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU="
-  "resolved" "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz"
-  "version" "1.1.7"
-  dependencies:
-    "bytes" "1"
-    "string_decoder" "0.10"
-
-"rc@^1.1.2":
-  "integrity" "sha1-x96XO3tGKXwEE2ay/T0jY7FpfGY="
-  "resolved" "https://registry.npmjs.org/rc/-/rc-1.2.0.tgz"
-  "version" "1.2.0"
-  dependencies:
-    "deep-extend" "~0.4.0"
-    "ini" "~1.3.0"
-    "minimist" "^1.2.0"
-    "strip-json-comments" "~2.0.1"
-
-"read-all-stream@^3.0.0":
-  "integrity" "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po="
-  "resolved" "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "pinkie-promise" "^2.0.0"
-    "readable-stream" "^2.0.0"
-
-"readable-stream@^1.0.26-4":
-  "integrity" "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
-  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-  "version" "1.1.14"
-  dependencies:
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.1"
-    "isarray" "0.0.1"
-    "string_decoder" "~0.10.x"
-
-"readable-stream@^2.0.0", "readable-stream@^2.0.1", "readable-stream@^2.0.4", "readable-stream@^2.0.5", "readable-stream@^2.1.5", "readable-stream@^2.2.2":
-  "integrity" "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY="
-  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
-  "version" "2.2.6"
-  dependencies:
-    "buffer-shims" "^1.0.0"
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.1"
-    "isarray" "~1.0.0"
-    "process-nextick-args" "~1.0.6"
-    "string_decoder" "~0.10.x"
-    "util-deprecate" "~1.0.1"
-
-"readable-stream@^2.0.2":
-  "integrity" "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw=="
-  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
-  "version" "2.3.6"
-  dependencies:
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.3"
-    "isarray" "~1.0.0"
-    "process-nextick-args" "~2.0.0"
-    "safe-buffer" "~5.1.1"
-    "string_decoder" "~1.1.1"
-    "util-deprecate" "~1.0.1"
-
-"readable-stream@>=1.0.33-1 <1.1.0-0":
-  "integrity" "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
-  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-  "version" "1.0.34"
-  dependencies:
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.1"
-    "isarray" "0.0.1"
-    "string_decoder" "~0.10.x"
-
-"readable-stream@~1.0.26-4":
-  "integrity" "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
-  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-  "version" "1.0.34"
-  dependencies:
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.1"
-    "isarray" "0.0.1"
-    "string_decoder" "~0.10.x"
-
-"readable-stream@~1.0.26":
-  "integrity" "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
-  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-  "version" "1.0.34"
-  dependencies:
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.1"
-    "isarray" "0.0.1"
-    "string_decoder" "~0.10.x"
-
-"readable-stream@~1.1.9":
-  "integrity" "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
-  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-  "version" "1.1.14"
-  dependencies:
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.1"
-    "isarray" "0.0.1"
-    "string_decoder" "~0.10.x"
-
-"readdirp@^2.0.0":
-  "integrity" "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ=="
-  "resolved" "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz"
-  "version" "2.2.1"
-  dependencies:
-    "graceful-fs" "^4.1.11"
-    "micromatch" "^3.1.10"
-    "readable-stream" "^2.0.2"
-
-"readline2@^1.0.1":
-  "integrity" "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU="
-  "resolved" "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
-  "version" "1.0.1"
-  dependencies:
-    "code-point-at" "^1.0.0"
-    "is-fullwidth-code-point" "^1.0.0"
-    "mute-stream" "0.0.5"
-
-"reduce-extract@^1.0.0":
-  "integrity" "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU="
-  "resolved" "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "test-value" "^1.0.1"
-
-"reduce-flatten@^1.0.1":
-  "integrity" "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
-  "resolved" "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz"
-  "version" "1.0.1"
-
-"reduce-flatten@^2.0.0":
-  "integrity" "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
-  "resolved" "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz"
-  "version" "2.0.0"
-
-"reduce-unique@^2.0.1":
-  "integrity" "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA=="
-  "resolved" "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz"
-  "version" "2.0.1"
-
-"reduce-without@^1.0.1":
-  "integrity" "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw="
-  "resolved" "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz"
-  "version" "1.0.1"
-  dependencies:
-    "test-value" "^2.0.0"
-
-"regenerate@^1.2.1":
-  "integrity" "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
-  "resolved" "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
-  "version" "1.3.2"
-
-"regenerator-runtime@^0.10.0":
-  "integrity" "sha1-jENnqQS1HqYqkIrDEL+Z/5CoKj4="
-  "resolved" "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz"
-  "version" "0.10.3"
-
-"regenerator-runtime@^0.11.0":
-  "integrity" "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-  "resolved" "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
-  "version" "0.11.0"
-
-"regenerator-transform@0.9.8":
-  "integrity" "sha1-D4i7K8A5Mt23trcxLmgHjwECbWw="
-  "resolved" "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
-  "version" "0.9.8"
-  dependencies:
-    "babel-runtime" "^6.18.0"
-    "babel-types" "^6.19.0"
-    "private" "^0.1.6"
-
-"regex-cache@^0.4.2":
-  "integrity" "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ=="
-  "resolved" "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz"
-  "version" "0.4.4"
-  dependencies:
-    "is-equal-shallow" "^0.1.3"
-
-"regex-not@^1.0.0", "regex-not@^1.0.2":
-  "integrity" "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A=="
-  "resolved" "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "extend-shallow" "^3.0.2"
-    "safe-regex" "^1.1.0"
-
-"regexpu-core@^2.0.0":
-  "integrity" "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
-  "resolved" "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "regenerate" "^1.2.1"
-    "regjsgen" "^0.2.0"
-    "regjsparser" "^0.1.4"
-
-"regjsgen@^0.2.0":
-  "integrity" "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-  "resolved" "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-  "version" "0.2.0"
-
-"regjsparser@^0.1.4":
-  "integrity" "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw="
-  "resolved" "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
-  "version" "0.1.5"
-  dependencies:
-    "jsesc" "~0.5.0"
-
-"remove-trailing-separator@^1.0.1":
-  "integrity" "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-  "resolved" "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
-  "version" "1.1.0"
-
-"repeat-element@^1.1.2":
-  "integrity" "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
-  "resolved" "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz"
-  "version" "1.1.3"
-
-"repeat-string@^1.5.2", "repeat-string@^1.6.1":
-  "integrity" "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-  "resolved" "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-  "version" "1.6.1"
-
-"repeating@^1.1.0":
-  "integrity" "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw="
-  "resolved" "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
-  "version" "1.1.3"
-  dependencies:
-    "is-finite" "^1.0.0"
-
-"repeating@^2.0.0":
-  "integrity" "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
-  "resolved" "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "is-finite" "^1.0.0"
-
-"replace-ext@0.0.1":
-  "integrity" "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-  "resolved" "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-  "version" "0.0.1"
-
-"req-all@^0.1.0":
-  "integrity" "sha1-EwBR4qzligLqy/ydRIV3pzapJzo="
-  "resolved" "https://registry.npmjs.org/req-all/-/req-all-0.1.0.tgz"
-  "version" "0.1.0"
-
-"request@^2.78.0":
-  "integrity" "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
-  "resolved" "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
-  "version" "2.81.0"
-  dependencies:
-    "aws-sign2" "~0.6.0"
-    "aws4" "^1.2.1"
-    "caseless" "~0.12.0"
-    "combined-stream" "~1.0.5"
-    "extend" "~3.0.0"
-    "forever-agent" "~0.6.1"
-    "form-data" "~2.1.1"
-    "har-validator" "~4.2.1"
-    "hawk" "~3.1.3"
-    "http-signature" "~1.1.0"
-    "is-typedarray" "~1.0.0"
-    "isstream" "~0.1.2"
-    "json-stringify-safe" "~5.0.1"
-    "mime-types" "~2.1.7"
-    "oauth-sign" "~0.8.1"
-    "performance-now" "^0.2.0"
-    "qs" "~6.4.0"
-    "safe-buffer" "^5.0.1"
-    "stringstream" "~0.0.4"
-    "tough-cookie" "~2.3.0"
-    "tunnel-agent" "^0.6.0"
-    "uuid" "^3.0.0"
-
-"request@2.51.0":
-  "integrity" "sha1-NdALvswBLlX5B7G9ng29V3v+8m4="
-  "resolved" "https://registry.npmjs.org/request/-/request-2.51.0.tgz"
-  "version" "2.51.0"
-  dependencies:
-    "aws-sign2" "~0.5.0"
-    "bl" "~0.9.0"
-    "caseless" "~0.8.0"
-    "combined-stream" "~0.0.5"
-    "forever-agent" "~0.5.0"
-    "form-data" "~0.2.0"
-    "hawk" "1.1.1"
-    "http-signature" "~0.10.0"
-    "json-stringify-safe" "~5.0.0"
-    "mime-types" "~1.0.1"
-    "node-uuid" "~1.4.0"
-    "oauth-sign" "~0.5.0"
-    "qs" "~2.3.1"
-    "stringstream" "~0.0.4"
-    "tough-cookie" ">=0.12.0"
-    "tunnel-agent" "~0.4.0"
-
-"require-relative@0.8.7":
-  "integrity" "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
-  "resolved" "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz"
-  "version" "0.8.7"
-
-"require-uncached@^1.0.2":
-  "integrity" "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM="
-  "resolved" "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz"
-  "version" "1.0.3"
-  dependencies:
-    "caller-path" "^0.1.0"
-    "resolve-from" "^1.0.0"
-
-"requires-port@1.x.x":
-  "integrity" "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-  "resolved" "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-  "version" "1.0.0"
-
-"requizzle@^0.2.3":
-  "integrity" "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ=="
-  "resolved" "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz"
-  "version" "0.2.3"
-  dependencies:
-    "lodash" "^4.17.14"
-
-"resolve-dir@^0.1.0":
-  "integrity" "sha1-shklmlYC+sXFxJatiUpujMQwJh4="
-  "resolved" "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
-  "version" "0.1.1"
-  dependencies:
-    "expand-tilde" "^1.2.2"
-    "global-modules" "^0.2.3"
-
-"resolve-from@^1.0.0":
-  "integrity" "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-  "resolved" "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-  "version" "1.0.1"
-
-"resolve-url@^0.2.1":
-  "integrity" "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-  "resolved" "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
-  "version" "0.2.1"
-
-"resolve@^1.1.6", "resolve@^1.1.7":
-  "integrity" "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU="
-  "resolved" "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz"
-  "version" "1.3.2"
-  dependencies:
-    "path-parse" "^1.0.5"
-
-"resolve@1.1.7":
-  "integrity" "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-  "resolved" "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-  "version" "1.1.7"
-
-"restore-cursor@^1.0.1":
-  "integrity" "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
-  "resolved" "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-  "version" "1.0.1"
-  dependencies:
-    "exit-hook" "^1.0.0"
-    "onetime" "^1.0.0"
-
-"ret@~0.1.10":
-  "integrity" "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-  "resolved" "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
-  "version" "0.1.15"
-
-"rimraf@^2.2.6":
-  "integrity" "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ="
-  "resolved" "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-  "version" "2.5.4"
-  dependencies:
-    "glob" "^7.0.5"
-
-"rimraf@^2.2.8", "rimraf@2.6.1":
-  "integrity" "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
-  "resolved" "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-  "version" "2.6.1"
-  dependencies:
-    "glob" "^7.0.5"
-
-"ripemd160@^1.0.0":
-  "integrity" "sha1-k6S71JQrxXS2mo+lfHHeEOzKfW4="
-  "resolved" "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
-  "version" "1.0.1"
-
-"rollup-plugin-babel@3.0.2":
-  "integrity" "sha512-ALGPBFtwJZcYHsNPM6RGJlEncTzAARPvZOGjNPZgDe5hS5t6sJGjiOWibEFVEz5LQN7S7spvCBILaS4N1Cql2w=="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.2.tgz"
-  "version" "3.0.2"
-  dependencies:
-    "rollup-pluginutils" "^1.5.0"
-
-"rollup-plugin-commonjs@8.1.0":
-  "integrity" "sha512-mxLU0oCZPakY+o1P9OeVG+yT7bGOFyRQf6pk3xden2+sEG2NP40CrKWw1h/BHZuK7yegRcOJMCfr/uzLmodrGQ=="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.1.0.tgz"
-  "version" "8.1.0"
-  dependencies:
-    "acorn" "^4.0.1"
-    "estree-walker" "^0.3.0"
-    "magic-string" "^0.19.0"
-    "resolve" "^1.1.7"
-    "rollup-pluginutils" "^2.0.1"
-
-"rollup-plugin-graphql-js-client-compiler@0.2.0":
-  "integrity" "sha512-3wC77mD62XeUijvfxTlMNkyjmKh3Lg4I0wgqWcJ/l1ZXnvTJ3q5X5Sgb15gCwBK57lNJP21zRh6CZTcVM20yAw=="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-graphql-js-client-compiler/-/rollup-plugin-graphql-js-client-compiler-0.2.0.tgz"
-  "version" "0.2.0"
-  dependencies:
-    "glob" "7.1.2"
-    "graphql-js-client-compiler" "0.2.0"
-    "rollup-pluginutils" "2.0.1"
-
-"rollup-plugin-json@2.3.0":
-  "integrity" "sha512-W45nZH7lmXgkSR/DkeyF4ks0YWFrMysdjUT049gTuAg+lwUEDBKI2+PztqW8UDSMlXCAeEONsLzpDDyBy9m+9A=="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-2.3.0.tgz"
-  "version" "2.3.0"
-  dependencies:
-    "rollup-pluginutils" "^2.0.1"
-
-"rollup-plugin-multi-entry@2.0.1":
-  "integrity" "sha1-Szrqjdxa/Jt/n/v7FEHATvOQcbQ="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-multi-entry/-/rollup-plugin-multi-entry-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "matched" "^0.4.3"
-
-"rollup-plugin-node-builtins@2.1.2":
-  "integrity" "sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz"
-  "version" "2.1.2"
-  dependencies:
-    "browserify-fs" "^1.0.0"
-    "buffer-es6" "^4.9.2"
-    "crypto-browserify" "^3.11.0"
-    "process-es6" "^0.11.2"
-
-"rollup-plugin-node-globals@1.1.0":
-  "integrity" "sha1-fv2NYR0TJzeCnoBOn1H1CWKvRR8="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-node-globals/-/rollup-plugin-node-globals-1.1.0.tgz"
-  "version" "1.1.0"
-  dependencies:
-    "acorn" "^4.0.1"
-    "buffer-es6" "^4.9.1"
-    "estree-walker" "^0.2.1"
-    "magic-string" "^0.16.0"
-    "process-es6" "^0.11.3"
-    "rollup-pluginutils" "^1.5.2"
-
-"rollup-plugin-node-resolve@3.0.0":
-  "integrity" "sha1-i4l8TDAw1QASd7BRSyXSygloPuA="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "browser-resolve" "^1.11.0"
-    "builtin-modules" "^1.1.0"
-    "is-module" "^1.0.0"
-    "resolve" "^1.1.6"
-
-"rollup-plugin-remap@0.0.3":
-  "integrity" "sha1-y/atjehTKWHPK0iXMRfMiEw6APo="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-remap/-/rollup-plugin-remap-0.0.3.tgz"
-  "version" "0.0.3"
-  dependencies:
-    "rollup-pluginutils" "1.5.2"
-
-"rollup-plugin-sizes@0.4.0":
-  "integrity" "sha1-LWDE3Sqf56GUyeavL9fRtka6JIU="
-  "resolved" "https://registry.npmjs.org/rollup-plugin-sizes/-/rollup-plugin-sizes-0.4.0.tgz"
-  "version" "0.4.0"
-  dependencies:
-    "filesize" "^3.5.10"
-    "lodash.foreach" "^4.5.0"
-    "lodash.sumby" "^4.6.0"
-    "module-details-from-path" "^1.0.3"
-
-"rollup-pluginutils@^1.5.0":
-  "integrity" "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg="
-  "resolved" "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz"
-  "version" "1.5.2"
-  dependencies:
-    "estree-walker" "^0.2.1"
-    "minimatch" "^3.0.2"
-
-"rollup-pluginutils@^1.5.2":
-  "integrity" "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg="
-  "resolved" "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz"
-  "version" "1.5.2"
-  dependencies:
-    "estree-walker" "^0.2.1"
-    "minimatch" "^3.0.2"
-
-"rollup-pluginutils@^2.0.1":
-  "integrity" "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA=="
-  "resolved" "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz"
-  "version" "2.3.3"
-  dependencies:
-    "estree-walker" "^0.5.2"
-    "micromatch" "^2.3.11"
-
-"rollup-pluginutils@1.5.2":
-  "integrity" "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg="
-  "resolved" "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz"
-  "version" "1.5.2"
-  dependencies:
-    "estree-walker" "^0.2.1"
-    "minimatch" "^3.0.2"
-
-"rollup-pluginutils@2.0.1":
-  "integrity" "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A="
-  "resolved" "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz"
-  "version" "2.0.1"
-  dependencies:
-    "estree-walker" "^0.3.0"
-    "micromatch" "^2.3.11"
-
-"rollup-watch@4.3.1":
-  "integrity" "sha512-6yjnIwfjpSrqA8IafyIu7fsEyeImNR4aDjA1bQ7KWeVuiA+Clfsx8+PGQkyABWIQzmauQ//tIJ5wAxLXsXs8qQ=="
-  "resolved" "https://registry.npmjs.org/rollup-watch/-/rollup-watch-4.3.1.tgz"
-  "version" "4.3.1"
-  dependencies:
-    "chokidar" "^1.7.0"
-    "require-relative" "0.8.7"
-    "rollup-pluginutils" "^2.0.1"
-
-"rollup@0.36.3":
-  "integrity" "sha1-yJrEeYKJJP+PacHURUHLTqL8Efw="
-  "resolved" "https://registry.npmjs.org/rollup/-/rollup-0.36.3.tgz"
-  "version" "0.36.3"
-  dependencies:
-    "source-map-support" "^0.4.0"
-
-"rollup@0.47.6":
-  "integrity" "sha512-bH3eWh7MzbiKTQcHQN7Ievqbs/yY7T+ZcJYboBYkp7BkRlAr2DXHPfiqlvlEH/M95giEBpinHEi/s9CVIgYT6w=="
-  "resolved" "https://registry.npmjs.org/rollup/-/rollup-0.47.6.tgz"
-  "version" "0.47.6"
-
-"run-async@^0.1.0":
-  "integrity" "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k="
-  "resolved" "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
-  "version" "0.1.0"
-  dependencies:
-    "once" "^1.3.0"
-
-"rx-lite@^3.1.2":
-  "integrity" "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
-  "resolved" "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-  "version" "3.1.2"
-
-"rx@^4.1.0":
-  "integrity" "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-  "resolved" "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
-  "version" "4.1.0"
-
-"rx@2.3.24":
-  "integrity" "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc="
-  "resolved" "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz"
-  "version" "2.3.24"
-
-"safe-buffer@^5.0.1", "safe-buffer@~5.1.0", "safe-buffer@~5.1.1":
-  "integrity" "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-  "resolved" "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-  "version" "5.1.2"
-
-"safe-json-parse@~1.0.1":
-  "integrity" "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c="
-  "resolved" "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz"
-  "version" "1.0.1"
-
-"safe-regex@^1.1.0":
-  "integrity" "sha1-QKNmnzsHfR6UPURinhV91IAjvy4="
-  "resolved" "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz"
-  "version" "1.1.0"
-  dependencies:
-    "ret" "~0.1.10"
-
-"safer-buffer@^2.0.2", "safer-buffer@^2.1.0", "safer-buffer@~2.1.0":
-  "integrity" "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-  "resolved" "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
-  "version" "2.1.2"
-
-"sax@>=0.6.0":
-  "integrity" "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-  "resolved" "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
-  "version" "1.2.4"
-
-"sax@1.2.1":
-  "integrity" "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-  "resolved" "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
-  "version" "1.2.1"
-
-"seek-bzip@^1.0.3", "seek-bzip@^1.0.5":
-  "integrity" "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w="
-  "resolved" "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
-  "version" "1.0.5"
-  dependencies:
-    "commander" "~2.8.1"
-
-"selenium-standalone@5.5.0":
-  "integrity" "sha1-AFhPSQ+TxSK0lzeHXAhPHvA3SFA="
-  "resolved" "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-5.5.0.tgz"
-  "version" "5.5.0"
-  dependencies:
-    "async" "1.2.1"
-    "commander" "2.6.0"
-    "lodash" "3.9.3"
-    "minimist" "1.1.0"
-    "mkdirp" "0.5.0"
-    "progress" "1.1.8"
-    "request" "2.51.0"
-    "urijs" "1.16.1"
-    "which" "1.1.1"
-    "yauzl" "^2.5.0"
-
-"semver@^5.3.0":
-  "integrity" "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-  "resolved" "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
-  "version" "5.6.0"
-
-"semver@^6.3.0":
-  "integrity" "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-  "resolved" "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
-  "version" "6.3.0"
-
-"semver@~2.3.1":
-  "integrity" "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI="
-  "resolved" "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-  "version" "2.3.2"
-
-"semver@5.2.0":
-  "integrity" "sha1-KBmVuAwUSCCUFd28TPUMJpzvVcU="
-  "resolved" "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
-  "version" "5.2.0"
-
-"set-getter@^0.1.0":
-  "integrity" "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y="
-  "resolved" "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz"
-  "version" "0.1.0"
-  dependencies:
-    "to-object-path" "^0.3.0"
-
-"set-immediate-shim@^1.0.0":
-  "integrity" "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-  "resolved" "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
-  "version" "1.0.1"
-
-"set-value@^0.4.3":
-  "integrity" "sha1-fbCPnT0i3H945Trzw79GZuzfzPE="
-  "resolved" "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz"
-  "version" "0.4.3"
-  dependencies:
-    "extend-shallow" "^2.0.1"
-    "is-extendable" "^0.1.1"
-    "is-plain-object" "^2.0.1"
-    "to-object-path" "^0.3.0"
-
-"set-value@^2.0.0":
-  "integrity" "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg=="
-  "resolved" "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "extend-shallow" "^2.0.1"
-    "is-extendable" "^0.1.1"
-    "is-plain-object" "^2.0.3"
-    "split-string" "^3.0.1"
-
-"sha.js@^2.3.6":
-  "integrity" "sha1-NwaMLEdra69ALRSknGf1l5IfY08="
-  "resolved" "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
-  "version" "2.4.8"
-  dependencies:
-    "inherits" "^2.0.1"
-
-"shelljs@^0.6.0":
-  "integrity" "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
-  "resolved" "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz"
-  "version" "0.6.1"
-
-"slash@^1.0.0":
-  "integrity" "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-  "resolved" "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-  "version" "1.0.0"
-
-"slice-ansi@0.0.4":
-  "integrity" "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-  "resolved" "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
-  "version" "0.0.4"
-
-"snapdragon-node@^2.0.1":
-  "integrity" "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw=="
-  "resolved" "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz"
-  "version" "2.1.1"
-  dependencies:
-    "define-property" "^1.0.0"
-    "isobject" "^3.0.0"
-    "snapdragon-util" "^3.0.1"
-
-"snapdragon-util@^3.0.1":
-  "integrity" "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ=="
-  "resolved" "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
-  "version" "3.0.1"
-  dependencies:
-    "kind-of" "^3.2.0"
-
-"snapdragon@^0.8.1":
-  "integrity" "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg=="
-  "resolved" "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz"
-  "version" "0.8.2"
-  dependencies:
-    "base" "^0.11.1"
-    "debug" "^2.2.0"
-    "define-property" "^0.2.5"
-    "extend-shallow" "^2.0.1"
-    "map-cache" "^0.2.2"
-    "source-map" "^0.5.6"
-    "source-map-resolve" "^0.5.0"
-    "use" "^3.1.0"
-
-"sntp@0.2.x":
-  "integrity" "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA="
-  "resolved" "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-  "version" "0.2.4"
-  dependencies:
-    "hoek" "0.9.x"
-
-"sntp@1.x.x":
-  "integrity" "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
-  "resolved" "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-  "version" "1.0.9"
-  dependencies:
-    "hoek" "2.x.x"
-
-"sort-array@^2.0.0":
-  "integrity" "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI="
-  "resolved" "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "array-back" "^1.0.4"
-    "object-get" "^2.1.0"
-    "typical" "^2.6.0"
-
-"sort-keys-length@^1.0.0":
-  "integrity" "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg="
-  "resolved" "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz"
-  "version" "1.0.1"
-  dependencies:
-    "sort-keys" "^1.0.0"
-
-"sort-keys@^1.0.0":
-  "integrity" "sha1-RBttTTRnmPG05J6JIK37oOVD+a0="
-  "resolved" "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
-  "version" "1.1.2"
-  dependencies:
-    "is-plain-obj" "^1.0.0"
-
-"source-map-resolve@^0.5.0":
-  "integrity" "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA=="
-  "resolved" "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz"
-  "version" "0.5.2"
-  dependencies:
-    "atob" "^2.1.1"
-    "decode-uri-component" "^0.2.0"
-    "resolve-url" "^0.2.1"
-    "source-map-url" "^0.4.0"
-    "urix" "^0.1.0"
-
-"source-map-support@^0.4.0":
-  "integrity" "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8="
-  "resolved" "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz"
-  "version" "0.4.14"
-  dependencies:
-    "source-map" "^0.5.6"
-
-"source-map-support@^0.4.15":
-  "integrity" "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg=="
-  "resolved" "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz"
-  "version" "0.4.16"
-  dependencies:
-    "source-map" "^0.5.6"
-
-"source-map-url@^0.4.0":
-  "integrity" "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-  "resolved" "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz"
-  "version" "0.4.0"
-
-"source-map@^0.5.0", "source-map@^0.5.6":
-  "integrity" "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-  "resolved" "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-  "version" "0.5.6"
-
-"source-map@^0.6.1":
-  "integrity" "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-  "resolved" "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
-  "version" "0.6.1"
-
-"sparkles@^1.0.0":
-  "integrity" "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
-  "resolved" "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-  "version" "1.0.0"
-
-"spawn-command@^0.0.2-1":
-  "integrity" "sha1-lUThpDygRfhTGqwaSMspva5iM44="
-  "resolved" "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz"
-  "version" "0.0.2"
-
-"split-string@^3.0.1", "split-string@^3.0.2":
-  "integrity" "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw=="
-  "resolved" "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "extend-shallow" "^3.0.0"
-
-"sprintf-js@~1.0.2":
-  "integrity" "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-  "resolved" "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-  "version" "1.0.3"
-
-"sshpk@^1.7.0":
-  "integrity" "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA=="
-  "resolved" "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz"
-  "version" "1.15.2"
-  dependencies:
-    "asn1" "~0.2.3"
-    "assert-plus" "^1.0.0"
-    "bcrypt-pbkdf" "^1.0.0"
-    "dashdash" "^1.12.0"
-    "ecc-jsbn" "~0.1.1"
-    "getpass" "^0.1.1"
-    "jsbn" "~0.1.0"
-    "safer-buffer" "^2.0.2"
-    "tweetnacl" "~0.14.0"
-
-"stat-mode@^0.2.0":
-  "integrity" "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
-  "resolved" "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz"
-  "version" "0.2.2"
-
-"static-extend@^0.1.1":
-  "integrity" "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY="
-  "resolved" "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
-  "version" "0.1.2"
-  dependencies:
-    "define-property" "^0.2.5"
-    "object-copy" "^0.1.0"
-
-"stream-combiner2@^1.1.1":
-  "integrity" "sha1-+02KFCDqNidk4hrUeAOXvry0HL4="
-  "resolved" "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
-  "version" "1.1.1"
-  dependencies:
-    "duplexer2" "~0.1.0"
-    "readable-stream" "^2.0.2"
-
-"stream-connect@^1.0.2":
-  "integrity" "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc="
-  "resolved" "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "array-back" "^1.0.2"
-
-"stream-shift@^1.0.0":
-  "integrity" "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-  "resolved" "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
-  "version" "1.0.0"
-
-"stream-via@^1.0.4":
-  "integrity" "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ=="
-  "resolved" "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz"
-  "version" "1.0.4"
-
-"string_decoder@~0.10.x", "string_decoder@0.10":
-  "integrity" "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-  "resolved" "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-  "version" "0.10.31"
-
-"string_decoder@~1.1.1":
-  "integrity" "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="
-  "resolved" "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  "version" "1.1.1"
-  dependencies:
-    "safe-buffer" "~5.1.0"
-
-"string-range@~1.2", "string-range@~1.2.1":
-  "integrity" "sha1-qJPtNH5yKZvIO++78qaSqNI51d0="
-  "resolved" "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz"
-  "version" "1.2.2"
-
-"string-template@~0.2.1":
-  "integrity" "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
-  "resolved" "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
-  "version" "0.2.1"
-
-"string-width@^1.0.1":
-  "integrity" "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
-  "resolved" "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "code-point-at" "^1.0.0"
-    "is-fullwidth-code-point" "^1.0.0"
-    "strip-ansi" "^3.0.0"
-
-"string-width@^2.0.0":
-  "integrity" "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4="
-  "resolved" "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "is-fullwidth-code-point" "^2.0.0"
-    "strip-ansi" "^3.0.0"
-
-"stringstream@~0.0.4":
-  "integrity" "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-  "resolved" "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz"
-  "version" "0.0.6"
-
-"strip-ansi@^0.3.0":
-  "integrity" "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA="
-  "resolved" "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
-  "version" "0.3.0"
-  dependencies:
-    "ansi-regex" "^0.2.1"
-
-"strip-ansi@^3.0.0":
-  "integrity" "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-  "resolved" "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-  "version" "3.0.1"
-  dependencies:
-    "ansi-regex" "^2.0.0"
-
-"strip-bom-stream@^1.0.0":
-  "integrity" "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4="
-  "resolved" "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "first-chunk-stream" "^1.0.0"
-    "strip-bom" "^2.0.0"
-
-"strip-bom@^2.0.0":
-  "integrity" "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
-  "resolved" "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "is-utf8" "^0.2.0"
-
-"strip-bom@^3.0.0":
-  "integrity" "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-  "resolved" "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-  "version" "3.0.0"
-
-"strip-dirs@^1.0.0":
-  "integrity" "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA="
-  "resolved" "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
-  "version" "1.1.1"
-  dependencies:
-    "chalk" "^1.0.0"
-    "get-stdin" "^4.0.1"
-    "is-absolute" "^0.1.5"
-    "is-natural-number" "^2.0.0"
-    "minimist" "^1.1.0"
-    "sum-up" "^1.0.1"
-
-"strip-dirs@^2.0.0":
-  "integrity" "sha1-YQzbKSggDaAAT0HcuQ/JXNkZoLY="
-  "resolved" "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "is-natural-number" "^4.0.1"
-
-"strip-eof@^1.0.0":
-  "integrity" "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-  "resolved" "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
-  "version" "1.0.0"
-
-"strip-json-comments@^3.0.1":
-  "integrity" "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
-  "resolved" "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz"
-  "version" "3.0.1"
-
-"strip-json-comments@~1.0.1":
-  "integrity" "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
-  "resolved" "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-  "version" "1.0.4"
-
-"strip-json-comments@~2.0.1":
-  "integrity" "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-  "resolved" "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-  "version" "2.0.1"
-
-"strip-outer@^1.0.0":
-  "integrity" "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g="
-  "resolved" "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "escape-string-regexp" "^1.0.2"
-
-"sum-up@^1.0.1":
-  "integrity" "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4="
-  "resolved" "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
-  "version" "1.0.3"
-  dependencies:
-    "chalk" "^1.0.0"
-
-"supports-color@^0.2.0":
-  "integrity" "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-  "resolved" "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-  "version" "0.2.0"
-
-"supports-color@^2.0.0":
-  "integrity" "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-  "resolved" "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-  "version" "2.0.0"
-
-"supports-color@^3.2.3":
-  "integrity" "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY="
-  "resolved" "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
-  "version" "3.2.3"
-  dependencies:
-    "has-flag" "^1.0.0"
-
-"supports-color@^5.3.0":
-  "integrity" "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="
-  "resolved" "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
-  "version" "5.5.0"
-  dependencies:
-    "has-flag" "^3.0.0"
-
-"supports-color@3.1.2":
-  "integrity" "sha1-cqJiiU2dQIuVbKBf83su2KbiotU="
-  "resolved" "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-  "version" "3.1.2"
-  dependencies:
-    "has-flag" "^1.0.0"
-
-"table-layout@^0.4.0":
-  "integrity" "sha1-xw/wRV2a3WO5H3wVp3kmKVwODn0="
-  "resolved" "https://registry.npmjs.org/table-layout/-/table-layout-0.4.0.tgz"
-  "version" "0.4.0"
-  dependencies:
-    "array-back" "^1.0.4"
-    "deep-extend" "~0.4.1"
-    "lodash.padend" "^4.6.1"
-    "typical" "^2.6.0"
-    "wordwrapjs" "^2.0.0"
-
-"table-layout@^0.4.2":
-  "integrity" "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw=="
-  "resolved" "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz"
-  "version" "0.4.5"
-  dependencies:
-    "array-back" "^2.0.0"
-    "deep-extend" "~0.6.0"
-    "lodash.padend" "^4.6.1"
-    "typical" "^2.6.1"
-    "wordwrapjs" "^3.0.0"
-
-"table@^3.7.8":
-  "integrity" "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8="
-  "resolved" "https://registry.npmjs.org/table/-/table-3.8.3.tgz"
-  "version" "3.8.3"
-  dependencies:
-    "ajv" "^4.7.0"
-    "ajv-keywords" "^1.0.0"
-    "chalk" "^1.1.1"
-    "lodash" "^4.0.0"
-    "slice-ansi" "0.0.4"
-    "string-width" "^2.0.0"
-
-"taffydb@2.6.2":
-  "integrity" "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
-  "resolved" "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz"
-  "version" "2.6.2"
-
-"tar-stream@^1.1.1":
-  "integrity" "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78="
-  "resolved" "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
-  "version" "1.5.2"
-  dependencies:
-    "bl" "^1.0.0"
-    "end-of-stream" "^1.0.0"
-    "readable-stream" "^2.0.0"
-    "xtend" "^4.0.0"
-
-"tar-stream@^1.5.2":
-  "integrity" "sha1-NlSc8E7RrumyowwBQyUiONr5QBY="
-  "resolved" "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz"
-  "version" "1.5.4"
-  dependencies:
-    "bl" "^1.0.0"
-    "end-of-stream" "^1.0.0"
-    "readable-stream" "^2.0.0"
-    "xtend" "^4.0.0"
-
-"temp-dir@^1.0.0":
-  "integrity" "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
-  "resolved" "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz"
-  "version" "1.0.0"
-
-"temp-path@^1.0.0":
-  "integrity" "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs="
-  "resolved" "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz"
-  "version" "1.0.0"
-
-"tempfile@^1.0.0":
-  "integrity" "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I="
-  "resolved" "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz"
-  "version" "1.1.1"
-  dependencies:
-    "os-tmpdir" "^1.0.0"
-    "uuid" "^2.0.1"
-
-"tempfile@^2.0.0":
-  "integrity" "sha1-awRGhWqbERTRhW/8vlCczLCXcmU="
-  "resolved" "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "temp-dir" "^1.0.0"
-    "uuid" "^3.0.1"
-
-"test-value@^1.0.1":
-  "integrity" "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8="
-  "resolved" "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz"
-  "version" "1.1.0"
-  dependencies:
-    "array-back" "^1.0.2"
-    "typical" "^2.4.2"
-
-"test-value@^2.0.0":
-  "integrity" "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE="
-  "resolved" "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz"
-  "version" "2.1.0"
-  dependencies:
-    "array-back" "^1.0.3"
-    "typical" "^2.6.0"
-
-"test-value@^3.0.0":
-  "integrity" "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ=="
-  "resolved" "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "array-back" "^2.0.0"
-    "typical" "^2.6.1"
-
-"text-table@~0.2.0":
-  "integrity" "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-  "resolved" "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-  "version" "0.2.0"
-
-"through@^2.3.6":
-  "integrity" "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-  "resolved" "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-  "version" "2.3.8"
-
-"through2-filter@^2.0.0":
-  "integrity" "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw="
-  "resolved" "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "through2" "~2.0.0"
-    "xtend" "~4.0.0"
-
-"through2@^0.6.0":
-  "integrity" "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg="
-  "resolved" "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-  "version" "0.6.5"
-  dependencies:
-    "readable-stream" ">=1.0.33-1 <1.1.0-0"
-    "xtend" ">=4.0.0 <4.1.0-0"
-
-"through2@^0.6.1":
-  "integrity" "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg="
-  "resolved" "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-  "version" "0.6.5"
-  dependencies:
-    "readable-stream" ">=1.0.33-1 <1.1.0-0"
-    "xtend" ">=4.0.0 <4.1.0-0"
-
-"through2@^2.0.0", "through2@~2.0.0":
-  "integrity" "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
-  "resolved" "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-  "version" "2.0.3"
-  dependencies:
-    "readable-stream" "^2.1.5"
-    "xtend" "~4.0.1"
-
-"time-stamp@^1.0.0":
-  "integrity" "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE="
-  "resolved" "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
-  "version" "1.0.1"
-
-"timed-out@^3.0.0":
-  "integrity" "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
-  "resolved" "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz"
-  "version" "3.1.3"
-
-"timed-out@^4.0.0":
-  "integrity" "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-  "resolved" "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz"
-  "version" "4.0.1"
-
-"tiny-lr@1.0.5":
-  "integrity" "sha512-YrxUSiMgOVh3PnAqtdAUQuUVEVRnqcRCxJ3BHrl/aaWV2fplKKB60oClM0GH2Gio2hcXvkxMUxsC/vXZrQePlg=="
-  "resolved" "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.0.5.tgz"
-  "version" "1.0.5"
-  dependencies:
-    "body" "^5.1.0"
-    "debug" "~2.6.7"
-    "faye-websocket" "~0.10.0"
-    "livereload-js" "^2.2.2"
-    "object-assign" "^4.1.0"
-    "qs" "^6.4.0"
-
-"tmp@0.0.29":
-  "integrity" "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA="
-  "resolved" "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz"
-  "version" "0.0.29"
-  dependencies:
-    "os-tmpdir" "~1.0.1"
-
-"to-absolute-glob@^0.1.1":
-  "integrity" "sha1-HN+kcqnvUMI57maZm2YsoOs5k38="
-  "resolved" "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz"
-  "version" "0.1.1"
-  dependencies:
-    "extend-shallow" "^2.0.1"
-
-"to-fast-properties@^1.0.1":
-  "integrity" "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA="
-  "resolved" "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-  "version" "1.0.2"
-
-"to-fast-properties@^1.0.3":
-  "integrity" "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-  "resolved" "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-  "version" "1.0.3"
-
-"to-fast-properties@^2.0.0":
-  "integrity" "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-  "resolved" "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
-  "version" "2.0.0"
-
-"to-object-path@^0.3.0":
-  "integrity" "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68="
-  "resolved" "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
-  "version" "0.3.0"
-  dependencies:
-    "kind-of" "^3.0.2"
-
-"to-regex-range@^2.1.0":
-  "integrity" "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg="
-  "resolved" "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz"
-  "version" "2.1.1"
-  dependencies:
-    "is-number" "^3.0.0"
-    "repeat-string" "^1.6.1"
-
-"to-regex@^3.0.1", "to-regex@^3.0.2":
-  "integrity" "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw=="
-  "resolved" "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz"
-  "version" "3.0.2"
-  dependencies:
-    "define-property" "^2.0.2"
-    "extend-shallow" "^3.0.2"
-    "regex-not" "^1.0.2"
-    "safe-regex" "^1.1.0"
-
-"topo@2.x.x":
-  "integrity" "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI="
-  "resolved" "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
-  "version" "2.0.2"
-  dependencies:
-    "hoek" "4.x.x"
-
-"tough-cookie@>=0.12.0":
-  "integrity" "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
-  "resolved" "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
-  "version" "2.3.2"
-  dependencies:
-    "punycode" "^1.4.1"
-
-"tough-cookie@~2.3.0":
-  "integrity" "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA=="
-  "resolved" "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz"
-  "version" "2.3.4"
-  dependencies:
-    "punycode" "^1.4.1"
-
-"tree-kill@^1.1.0":
-  "integrity" "sha1-yWPc8DciiS7FnLpWnpQLcZVNFyk="
-  "resolved" "https://registry.npmjs.org/tree-kill/-/tree-kill-1.1.0.tgz"
-  "version" "1.1.0"
-
-"trim-repeated@^1.0.0":
-  "integrity" "sha1-42RqLqTokTEr9+rObPsFOAvAHCE="
-  "resolved" "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "escape-string-regexp" "^1.0.2"
-
-"trim-right@^1.0.1":
-  "integrity" "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-  "resolved" "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-  "version" "1.0.1"
-
-"tryit@^1.0.1":
-  "integrity" "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
-  "resolved" "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
-  "version" "1.0.3"
-
-"tunnel-agent@^0.4.0", "tunnel-agent@~0.4.0":
-  "integrity" "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-  "resolved" "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-  "version" "0.4.3"
-
-"tunnel-agent@^0.6.0":
-  "integrity" "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
-  "resolved" "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-  "version" "0.6.0"
-  dependencies:
-    "safe-buffer" "^5.0.1"
-
-"tweetnacl@^0.14.3", "tweetnacl@~0.14.0":
-  "integrity" "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-  "resolved" "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-  "version" "0.14.5"
-
-"type-check@~0.3.2":
-  "integrity" "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I="
-  "resolved" "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-  "version" "0.3.2"
-  dependencies:
-    "prelude-ls" "~1.1.2"
-
-"typedarray-to-buffer@~1.0.0":
-  "integrity" "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
-  "resolved" "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz"
-  "version" "1.0.4"
-
-"typedarray@^0.0.6":
-  "integrity" "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-  "resolved" "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-  "version" "0.0.6"
-
-"typical@^2.4.2", "typical@^2.6.0":
-  "integrity" "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0="
-  "resolved" "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-  "version" "2.6.0"
-
-"typical@^2.6.1":
-  "integrity" "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
-  "resolved" "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz"
-  "version" "2.6.1"
-
-"typical@^4.0.0":
-  "integrity" "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
-  "resolved" "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz"
-  "version" "4.0.0"
-
-"uc.micro@^1.0.1", "uc.micro@^1.0.5":
-  "integrity" "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-  "resolved" "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
-  "version" "1.0.6"
-
-"uglify-js@^3.1.4":
-  "integrity" "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g=="
-  "resolved" "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz"
-  "version" "3.17.4"
-
-"unbzip2-stream@^1.0.9":
-  "integrity" "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og=="
-  "resolved" "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz"
-  "version" "1.2.5"
-  dependencies:
-    "buffer" "^3.0.1"
-    "through" "^2.3.6"
-
-"underscore@~1.9.1":
-  "integrity" "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-  "resolved" "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz"
-  "version" "1.9.1"
-
-"union-value@^1.0.0":
-  "integrity" "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ="
-  "resolved" "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "arr-union" "^3.1.0"
-    "get-value" "^2.0.6"
-    "is-extendable" "^0.1.1"
-    "set-value" "^0.4.3"
-
-"union@~0.4.3":
-  "integrity" "sha1-GY+9rrolTniLDvy2MLwR8kopWeA="
-  "resolved" "https://registry.npmjs.org/union/-/union-0.4.6.tgz"
-  "version" "0.4.6"
-  dependencies:
-    "qs" "~2.3.3"
-
-"unique-stream@^2.0.2":
-  "integrity" "sha1-WqADz76Uxf+GbE59ZouxxNuts2k="
-  "resolved" "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
-  "version" "2.2.1"
-  dependencies:
-    "json-stable-stringify" "^1.0.0"
-    "through2-filter" "^2.0.0"
-
-"unset-value@^1.0.0":
-  "integrity" "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk="
-  "resolved" "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "has-value" "^0.3.1"
-    "isobject" "^3.0.0"
-
-"unzip-response@^1.0.2":
-  "integrity" "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-  "resolved" "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz"
-  "version" "1.0.2"
-
-"urijs@1.16.1":
-  "integrity" "sha1-hZrTGJD1+VKHJ76J8ZMslPtHMeI="
-  "resolved" "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz"
-  "version" "1.16.1"
-
-"urix@^0.1.0":
-  "integrity" "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-  "resolved" "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
-  "version" "0.1.0"
-
-"url-join@^2.0.2":
-  "integrity" "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc="
-  "resolved" "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz"
-  "version" "2.0.2"
-
-"url-parse-lax@^1.0.0":
-  "integrity" "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
-  "resolved" "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "prepend-http" "^1.0.1"
-
-"url-regex@^3.0.0":
-  "integrity" "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ="
-  "resolved" "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz"
-  "version" "3.2.0"
-  dependencies:
-    "ip-regex" "^1.0.1"
-
-"url-to-options@^1.0.1":
-  "integrity" "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-  "resolved" "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz"
-  "version" "1.0.1"
-
-"url@0.10.3":
-  "integrity" "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ="
-  "resolved" "https://registry.npmjs.org/url/-/url-0.10.3.tgz"
-  "version" "0.10.3"
-  dependencies:
-    "punycode" "1.3.2"
-    "querystring" "0.2.0"
-
-"use@^3.1.0":
-  "integrity" "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
-  "resolved" "https://registry.npmjs.org/use/-/use-3.1.1.tgz"
-  "version" "3.1.1"
-
-"user-home@^2.0.0":
-  "integrity" "sha1-nHC/2Babwdy/SGBODwS4tJzenp8="
-  "resolved" "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "os-homedir" "^1.0.0"
-
-"util-deprecate@~1.0.1":
-  "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-  "resolved" "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-  "version" "1.0.2"
-
-"util.promisify@^1.0.0":
-  "integrity" "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA=="
-  "resolved" "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz"
-  "version" "1.0.0"
-  dependencies:
-    "define-properties" "^1.1.2"
-    "object.getownpropertydescriptors" "^2.0.3"
-
-"uuid@^2.0.1":
-  "integrity" "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-  "resolved" "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
-  "version" "2.0.3"
-
-"uuid@^3.0.0":
-  "integrity" "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-  "resolved" "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
-  "version" "3.3.2"
-
-"uuid@^3.0.1":
-  "integrity" "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-  "resolved" "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-  "version" "3.0.1"
-
-"uuid@3.1.0":
-  "integrity" "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-  "resolved" "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-  "version" "3.1.0"
-
-"vali-date@^1.0.0":
-  "integrity" "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
-  "resolved" "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz"
-  "version" "1.0.0"
-
-"verror@1.10.0":
-  "integrity" "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA="
-  "resolved" "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
-  "version" "1.10.0"
-  dependencies:
-    "assert-plus" "^1.0.0"
-    "core-util-is" "1.0.2"
-    "extsprintf" "^1.2.0"
-
-"vinyl-assign@^1.0.1":
-  "integrity" "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU="
-  "resolved" "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz"
-  "version" "1.2.1"
-  dependencies:
-    "object-assign" "^4.0.1"
-    "readable-stream" "^2.0.0"
-
-"vinyl-fs@^2.2.0":
-  "integrity" "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk="
-  "resolved" "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz"
-  "version" "2.4.4"
-  dependencies:
-    "duplexify" "^3.2.0"
-    "glob-stream" "^5.3.2"
-    "graceful-fs" "^4.0.0"
-    "gulp-sourcemaps" "1.6.0"
-    "is-valid-glob" "^0.3.0"
-    "lazystream" "^1.0.0"
-    "lodash.isequal" "^4.0.0"
-    "merge-stream" "^1.0.0"
-    "mkdirp" "^0.5.0"
-    "object-assign" "^4.0.0"
-    "readable-stream" "^2.0.4"
-    "strip-bom" "^2.0.0"
-    "strip-bom-stream" "^1.0.0"
-    "through2" "^2.0.0"
-    "through2-filter" "^2.0.0"
-    "vali-date" "^1.0.0"
-    "vinyl" "^1.0.0"
-
-"vinyl@^0.4.3":
-  "integrity" "sha1-LzVsh6VQolVGHza76ypbqL94SEc="
-  "resolved" "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
-  "version" "0.4.6"
-  dependencies:
-    "clone" "^0.2.0"
-    "clone-stats" "^0.0.1"
-
-"vinyl@^0.5.0":
-  "integrity" "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4="
-  "resolved" "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
-  "version" "0.5.3"
-  dependencies:
-    "clone" "^1.0.0"
-    "clone-stats" "^0.0.1"
-    "replace-ext" "0.0.1"
-
-"vinyl@^1.0.0":
-  "integrity" "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ="
-  "resolved" "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
-  "version" "1.2.0"
-  dependencies:
-    "clone" "^1.0.0"
-    "clone-stats" "^0.0.1"
-    "replace-ext" "0.0.1"
-
-"vlq@^0.2.1":
-  "integrity" "sha1-FEOdcRiR5oJTVGf4WHxWMOQiKmw="
-  "resolved" "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz"
-  "version" "0.2.1"
-
-"wait-on@2.0.2":
-  "integrity" "sha1-CoT9BwJMb8Joyw6r5YW+IXqvK6o="
-  "resolved" "https://registry.npmjs.org/wait-on/-/wait-on-2.0.2.tgz"
-  "version" "2.0.2"
-  dependencies:
-    "core-js" "^2.4.1"
-    "joi" "^9.2.0"
-    "minimist" "^1.2.0"
-    "request" "^2.78.0"
-    "rx" "^4.1.0"
-
-"walk-back@^2.0.1":
-  "integrity" "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ="
-  "resolved" "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz"
-  "version" "2.0.1"
-
-"walk-back@^3.0.1":
-  "integrity" "sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ=="
-  "resolved" "https://registry.npmjs.org/walk-back/-/walk-back-3.0.1.tgz"
-  "version" "3.0.1"
-
-"ware@^1.2.0":
-  "integrity" "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q="
-  "resolved" "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz"
-  "version" "1.3.0"
-  dependencies:
-    "wrap-fn" "^0.1.0"
-
-"websocket-driver@>=0.5.1":
-  "integrity" "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY="
-  "resolved" "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
-  "version" "0.6.5"
-  dependencies:
-    "websocket-extensions" ">=0.1.1"
-
-"websocket-extensions@>=0.1.1":
-  "integrity" "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
-  "resolved" "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
-  "version" "0.1.1"
-
-"whatwg-fetch@2.0.3":
-  "integrity" "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-  "resolved" "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-  "version" "2.0.3"
-
-"which@^1.2.12":
-  "integrity" "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
-  "resolved" "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-  "version" "1.2.14"
-  dependencies:
-    "isexe" "^2.0.0"
-
-"which@1.1.1":
-  "integrity" "sha1-nOUSRZlGFm4SwIPwjsBzOA/Iy7s="
-  "resolved" "https://registry.npmjs.org/which/-/which-1.1.1.tgz"
-  "version" "1.1.1"
-  dependencies:
-    "is-absolute" "^0.1.7"
-
-"wordwrap@^1.0.0", "wordwrap@~1.0.0":
-  "integrity" "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-  "resolved" "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-  "version" "1.0.0"
-
-"wordwrap@~0.0.2":
-  "integrity" "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-  "resolved" "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-  "version" "0.0.3"
-
-"wordwrapjs@^2.0.0":
-  "integrity" "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA="
-  "resolved" "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz"
-  "version" "2.0.0"
-  dependencies:
-    "array-back" "^1.0.3"
-    "feature-detect-es6" "^1.3.1"
-    "reduce-flatten" "^1.0.1"
-    "typical" "^2.6.0"
-
-"wordwrapjs@^3.0.0":
-  "integrity" "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw=="
-  "resolved" "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "reduce-flatten" "^1.0.1"
-    "typical" "^2.6.1"
-
-"wrap-fn@^0.1.0":
-  "integrity" "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU="
-  "resolved" "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz"
-  "version" "0.1.5"
-  dependencies:
-    "co" "3.1.0"
-
-"wrappy@1":
-  "integrity" "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-  "resolved" "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-  "version" "1.0.2"
-
-"write@^0.2.1":
-  "integrity" "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c="
-  "resolved" "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
-  "version" "0.2.1"
-  dependencies:
-    "mkdirp" "^0.5.1"
-
-"xml2js@0.4.17":
-  "integrity" "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
-  "resolved" "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz"
-  "version" "0.4.17"
-  dependencies:
-    "sax" ">=0.6.0"
-    "xmlbuilder" "^4.1.0"
-
-"xmlbuilder@^4.1.0", "xmlbuilder@4.2.1":
-  "integrity" "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
-  "resolved" "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
-  "version" "4.2.1"
-  dependencies:
-    "lodash" "^4.0.0"
-
-"xmlcreate@^2.0.0":
-  "integrity" "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA=="
-  "resolved" "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz"
-  "version" "2.0.1"
-
-"xtend@^2.2.0":
-  "integrity" "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
-  "resolved" "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz"
-  "version" "2.2.0"
-
-"xtend@^4.0.0", "xtend@>=4.0.0 <4.1.0-0", "xtend@~4.0.0", "xtend@~4.0.1":
-  "integrity" "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-  "resolved" "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-  "version" "4.0.1"
-
-"xtend@~2.0.4":
-  "integrity" "sha1-XqZXptukRwacLlnFihE4ywxebO4="
-  "resolved" "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz"
-  "version" "2.0.6"
-  dependencies:
-    "is-object" "~0.1.2"
-    "object-keys" "~0.2.0"
-
-"xtend@~2.1.2":
-  "integrity" "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
-  "resolved" "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
-  "version" "2.1.2"
-  dependencies:
-    "object-keys" "~0.4.0"
-
-"xtend@~3.0.0":
-  "integrity" "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-  "resolved" "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-  "version" "3.0.0"
-
-"yargs-parser@^10.0.0":
-  "integrity" "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ=="
-  "resolved" "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz"
-  "version" "10.1.0"
-  dependencies:
-    "camelcase" "^4.1.0"
-
-"yauzl@^2.2.1", "yauzl@^2.5.0":
-  "integrity" "sha1-4h2EeGi0lvwp6uwj7of90z6bK84="
-  "resolved" "https://registry.npmjs.org/yauzl/-/yauzl-2.7.0.tgz"
-  "version" "2.7.0"
-  dependencies:
-    "buffer-crc32" "~0.2.3"
-    "fd-slicer" "~1.0.1"
-
-"yauzl@^2.4.2":
-  "integrity" "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI="
-  "resolved" "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz"
-  "version" "2.8.0"
-  dependencies:
-    "buffer-crc32" "~0.2.3"
-    "fd-slicer" "~1.0.1"
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+  integrity sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=
+  dependencies:
+    brace-expansion "^1.0.0"
+
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@0.0.8, minimist@~0.0.1:
+  version "0.0.8"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minimist@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
+  integrity sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=
+
+minimist@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
+minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz"
+  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
+mkdirp2@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz"
+  integrity sha1-zI3YJl8fBuLY9bELblL04FC+0hs=
+
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz"
+  integrity sha1-HXMHam35hs2TROFecfzAWkyavxI=
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
+mocha@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz"
+  integrity sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
+
+module-details-from-path@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz"
+  integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
+
+moment@2.x.x:
+  version "2.18.1"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
+  integrity sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=
+
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+  integrity sha1-riXPJRKziFodldfwN4aNhDESR2U=
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+multimatch@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz"
+  integrity sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=
+  dependencies:
+    array-differ "^1.0.0"
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    minimatch "^3.0.0"
+
+multipipe@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
+  integrity sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=
+  dependencies:
+    duplexer2 "0.0.2"
+
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+  integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
+
+nan@^2.12.1:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3"
+  integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+neo-async@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+node-fetch@1.6.3, node-fetch@^1.3.3:
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
+  integrity sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
+node-fetch@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz"
+  integrity sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
+node-jq@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/node-jq/-/node-jq-0.7.0.tgz"
+  integrity sha512-5oMKLqc1KF+1K8cm84NyDP8ZBT2lo8H7tDC7Xiywj295ukEmE9Wo8XDIKz/ehmJAcVwAPWFg40pLfuZjWJmcfg==
+  dependencies:
+    bin-build "^2.2.0"
+    download "^6.0.0"
+    is-valid-path "^0.1.1"
+    strip-eof "^1.0.0"
+    tempfile "^2.0.0"
+
+node-releases@^1.1.75:
+  version "1.1.75"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz"
+  integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
+
+node-status-codes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
+  integrity sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=
+
+node-uuid@~1.4.0:
+  version "1.4.8"
+  resolved "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
+  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
+
+normalize-path@^2.0.0, normalize-path@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+npm-conf@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.2.tgz"
+  integrity sha512-dotwbpwVzfNB/2EF3A2wjK5tEMLggKfuA/8TG6WvBB1Zrv+JsvF7E8ei9B/HGq211st/GwXFbREcNJvJ1eySUQ==
+  dependencies:
+    config-chain "^1.1.11"
+    pify "^3.0.0"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+oauth-sign@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+  integrity sha1-12f1FpMlYg6rLgh+8MRy53PbZGE=
+
+oauth-sign@~0.8.1:
+  version "0.8.2"
+  resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+  integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
+
+object-assign@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+  integrity sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=
+
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+
+object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz"
+  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-get@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz"
+  integrity sha1-ciu9tgA576R8rTxtws5RqFwCxa4=
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+  integrity sha1-xUYBd4rVYPEULODgG8yotW0TQm0=
+
+object-keys@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz"
+  integrity sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=
+  dependencies:
+    foreach "~2.0.1"
+    indexof "~0.0.1"
+    is "~0.2.6"
+
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+  integrity sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=
+
+object-to-spawn-args@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz"
+  integrity sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
+  dependencies:
+    isobject "^3.0.0"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz"
+  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
+
+object.omit@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
+  integrity sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=
+  dependencies:
+    for-own "^0.1.4"
+    is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz"
+  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
+  dependencies:
+    isobject "^3.0.1"
+
+octal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz"
+  integrity sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws=
+
+once@^1.3.0, once@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+once@~1.3.0:
+  version "1.3.3"
+  resolved "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+  integrity sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=
+  dependencies:
+    wrappy "1"
+
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+  integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
+
+opener@~1.4.0:
+  version "1.4.3"
+  resolved "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
+  integrity sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=
+
+optimist@0.6.x:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
+
+optionator@^0.8.1, optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
+  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
+ordered-read-streams@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
+  integrity sha1-cTfmmzKYuzQiR6G77jiByA4v14s=
+  dependencies:
+    is-stream "^1.0.1"
+    readable-stream "^2.0.1"
+
+os-homedir@^1.0.0, os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+p-cancelable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz"
+  integrity sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==
+
+p-event@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz"
+  integrity sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=
+  dependencies:
+    p-timeout "^1.1.1"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-timeout@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.0.tgz"
+  integrity sha1-mCD5lDTFgXhotPNICe5SkWYNW2w=
+  dependencies:
+    p-finally "^1.0.0"
+
+parse-asn1@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
+  integrity sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=
+  dependencies:
+    asn1.js "^4.0.0"
+    browserify-aes "^1.0.0"
+    create-hash "^1.1.0"
+    evp_bytestokey "^1.0.0"
+    pbkdf2 "^3.0.3"
+
+parse-glob@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+  integrity sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
+  dependencies:
+    glob-base "^0.3.0"
+    is-dotfile "^1.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.0"
+
+parse-json@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+  integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
+  dependencies:
+    error-ex "^1.2.0"
+
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
+  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
+
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+  integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
+  dependencies:
+    pinkie-promise "^2.0.0"
+
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-is-inside@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+  integrity sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
+
+pbkdf2@^3.0.3:
+  version "3.0.9"
+  resolved "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
+  integrity sha1-8sSyWmAAWLPDdzwIbDfbvuH/5pM=
+  dependencies:
+    create-hmac "^1.1.2"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+  integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
+
+pify@^2.0.0, pify@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+  integrity sha1-ektQio1bstYp1EcFb/TpyTFM89Q=
+  dependencies:
+    find-up "^1.0.0"
+
+pkg-up@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
+  integrity sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=
+  dependencies:
+    find-up "^1.0.0"
+
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
+  integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
+
+portfinder@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz"
+  integrity sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=
+  dependencies:
+    async "^1.5.2"
+    debug "^2.2.0"
+    mkdirp "0.5.x"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
+  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prepend-http@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
+  integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+preserve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+  integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
+
+private@^0.1.6, private@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+  integrity sha1-aM5eih7woju1cMwoU3tTMqumPvE=
+
+process-es6@^0.11.2, process-es6@^0.11.3:
+  version "0.11.6"
+  resolved "https://registry.npmjs.org/process-es6/-/process-es6-0.11.6.tgz"
+  integrity sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g=
+
+process-nextick-args@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+  integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
+  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+
+progress@1.1.8, progress@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+  integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+  integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+prr@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+  integrity sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=
+
+public-encrypt@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
+  integrity sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=
+  dependencies:
+    bn.js "^4.1.0"
+    browserify-rsa "^4.0.0"
+    create-hash "^1.1.0"
+    parse-asn1 "^5.0.0"
+    randombytes "^2.0.1"
+
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
+qs@^6.4.0:
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz"
+  integrity sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==
+
+qs@~2.3.1, qs@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+  integrity sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=
+
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+  integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+ramda@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz"
+  integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
+
+randomatic@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz"
+  integrity sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==
+  dependencies:
+    is-number "^4.0.0"
+    kind-of "^6.0.0"
+    math-random "^1.0.1"
+
+randombytes@^2.0.0, randombytes@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
+  integrity sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew=
+
+raw-body@~1.1.0:
+  version "1.1.7"
+  resolved "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz"
+  integrity sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=
+  dependencies:
+    bytes "1"
+    string_decoder "0.10"
+
+rc@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/rc/-/rc-1.2.0.tgz"
+  integrity sha1-x96XO3tGKXwEE2ay/T0jY7FpfGY=
+  dependencies:
+    deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+read-all-stream@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
+  integrity sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=
+  dependencies:
+    pinkie-promise "^2.0.0"
+    readable-stream "^2.0.0"
+
+"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.26, readable-stream@~1.0.26-4:
+  version "1.0.34"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@^1.0.26-4, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@^2.2.2:
+  version "2.2.6"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
+  integrity sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=
+  dependencies:
+    buffer-shims "^1.0.0"
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.0.2:
+  version "2.3.6"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readdirp@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz"
+  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    readable-stream "^2.0.2"
+
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
+  integrity sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
+
+reduce-extract@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz"
+  integrity sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=
+  dependencies:
+    test-value "^1.0.1"
+
+reduce-flatten@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz"
+  integrity sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=
+
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
+
+reduce-unique@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz"
+  integrity sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==
+
+reduce-without@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz"
+  integrity sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=
+  dependencies:
+    test-value "^2.0.0"
+
+regenerate@^1.2.1:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+  integrity sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=
+
+regenerator-runtime@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz"
+  integrity sha1-jENnqQS1HqYqkIrDEL+Z/5CoKj4=
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+  integrity sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==
+
+regenerator-transform@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
+  integrity sha1-D4i7K8A5Mt23trcxLmgHjwECbWw=
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
+
+regex-cache@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz"
+  integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
+  dependencies:
+    is-equal-shallow "^0.1.3"
+
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz"
+  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
+
+regexpu-core@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+  integrity sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=
+  dependencies:
+    regenerate "^1.2.1"
+    regjsgen "^0.2.0"
+    regjsparser "^0.1.4"
+
+regjsgen@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+  integrity sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=
+
+regjsparser@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+  integrity sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=
+  dependencies:
+    jsesc "~0.5.0"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+repeat-element@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+
+repeat-string@^1.5.2, repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+repeating@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+  integrity sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=
+  dependencies:
+    is-finite "^1.0.0"
+
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+  integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
+  dependencies:
+    is-finite "^1.0.0"
+
+replace-ext@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+  integrity sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=
+
+req-all@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/req-all/-/req-all-0.1.0.tgz"
+  integrity sha1-EwBR4qzligLqy/ydRIV3pzapJzo=
+
+request@2.51.0:
+  version "2.51.0"
+  resolved "https://registry.npmjs.org/request/-/request-2.51.0.tgz"
+  integrity sha1-NdALvswBLlX5B7G9ng29V3v+8m4=
+  dependencies:
+    aws-sign2 "~0.5.0"
+    bl "~0.9.0"
+    caseless "~0.8.0"
+    combined-stream "~0.0.5"
+    forever-agent "~0.5.0"
+    form-data "~0.2.0"
+    hawk "1.1.1"
+    http-signature "~0.10.0"
+    json-stringify-safe "~5.0.0"
+    mime-types "~1.0.1"
+    node-uuid "~1.4.0"
+    oauth-sign "~0.5.0"
+    qs "~2.3.1"
+    stringstream "~0.0.4"
+    tough-cookie ">=0.12.0"
+    tunnel-agent "~0.4.0"
+
+request@^2.78.0:
+  version "2.81.0"
+  resolved "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+  integrity sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~4.2.1"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    performance-now "^0.2.0"
+    qs "~6.4.0"
+    safe-buffer "^5.0.1"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.0.0"
+
+require-relative@0.8.7:
+  version "0.8.7"
+  resolved "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz"
+  integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
+
+require-uncached@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz"
+  integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
+requires-port@1.x.x:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+requizzle@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz"
+  integrity sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==
+  dependencies:
+    lodash "^4.17.14"
+
+resolve-dir@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+  integrity sha1-shklmlYC+sXFxJatiUpujMQwJh4=
+  dependencies:
+    expand-tilde "^1.2.2"
+    global-modules "^0.2.3"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+  integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
+
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+
+resolve@^1.1.6, resolve@^1.1.7:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz"
+  integrity sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=
+  dependencies:
+    path-parse "^1.0.5"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+  integrity sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+rimraf@2.6.1, rimraf@^2.2.8:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+  integrity sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=
+  dependencies:
+    glob "^7.0.5"
+
+rimraf@^2.2.6:
+  version "2.5.4"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+  integrity sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=
+  dependencies:
+    glob "^7.0.5"
+
+ripemd160@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+  integrity sha1-k6S71JQrxXS2mo+lfHHeEOzKfW4=
+
+rollup-plugin-babel@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.2.tgz"
+  integrity sha512-ALGPBFtwJZcYHsNPM6RGJlEncTzAARPvZOGjNPZgDe5hS5t6sJGjiOWibEFVEz5LQN7S7spvCBILaS4N1Cql2w==
+  dependencies:
+    rollup-pluginutils "^1.5.0"
+
+rollup-plugin-commonjs@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.1.0.tgz"
+  integrity sha512-mxLU0oCZPakY+o1P9OeVG+yT7bGOFyRQf6pk3xden2+sEG2NP40CrKWw1h/BHZuK7yegRcOJMCfr/uzLmodrGQ==
+  dependencies:
+    acorn "^4.0.1"
+    estree-walker "^0.3.0"
+    magic-string "^0.19.0"
+    resolve "^1.1.7"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-graphql-js-client-compiler@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-graphql-js-client-compiler/-/rollup-plugin-graphql-js-client-compiler-0.2.0.tgz"
+  integrity sha512-3wC77mD62XeUijvfxTlMNkyjmKh3Lg4I0wgqWcJ/l1ZXnvTJ3q5X5Sgb15gCwBK57lNJP21zRh6CZTcVM20yAw==
+  dependencies:
+    glob "7.1.2"
+    graphql-js-client-compiler "0.2.0"
+    rollup-pluginutils "2.0.1"
+
+rollup-plugin-json@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-2.3.0.tgz"
+  integrity sha512-W45nZH7lmXgkSR/DkeyF4ks0YWFrMysdjUT049gTuAg+lwUEDBKI2+PztqW8UDSMlXCAeEONsLzpDDyBy9m+9A==
+  dependencies:
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-multi-entry@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/rollup-plugin-multi-entry/-/rollup-plugin-multi-entry-2.0.1.tgz"
+  integrity sha1-Szrqjdxa/Jt/n/v7FEHATvOQcbQ=
+  dependencies:
+    matched "^0.4.3"
+
+rollup-plugin-node-builtins@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz"
+  integrity sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k=
+  dependencies:
+    browserify-fs "^1.0.0"
+    buffer-es6 "^4.9.2"
+    crypto-browserify "^3.11.0"
+    process-es6 "^0.11.2"
+
+rollup-plugin-node-globals@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-node-globals/-/rollup-plugin-node-globals-1.1.0.tgz"
+  integrity sha1-fv2NYR0TJzeCnoBOn1H1CWKvRR8=
+  dependencies:
+    acorn "^4.0.1"
+    buffer-es6 "^4.9.1"
+    estree-walker "^0.2.1"
+    magic-string "^0.16.0"
+    process-es6 "^0.11.3"
+    rollup-pluginutils "^1.5.2"
+
+rollup-plugin-node-resolve@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz"
+  integrity sha1-i4l8TDAw1QASd7BRSyXSygloPuA=
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
+
+rollup-plugin-remap@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/rollup-plugin-remap/-/rollup-plugin-remap-0.0.3.tgz"
+  integrity sha1-y/atjehTKWHPK0iXMRfMiEw6APo=
+  dependencies:
+    rollup-pluginutils "1.5.2"
+
+rollup-plugin-sizes@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-sizes/-/rollup-plugin-sizes-0.4.0.tgz"
+  integrity sha1-LWDE3Sqf56GUyeavL9fRtka6JIU=
+  dependencies:
+    filesize "^3.5.10"
+    lodash.foreach "^4.5.0"
+    lodash.sumby "^4.6.0"
+    module-details-from-path "^1.0.3"
+
+rollup-pluginutils@1.5.2, rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz"
+  integrity sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=
+  dependencies:
+    estree-walker "^0.2.1"
+    minimatch "^3.0.2"
+
+rollup-pluginutils@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz"
+  integrity sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
+
+rollup-pluginutils@^2.0.1:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz"
+  integrity sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==
+  dependencies:
+    estree-walker "^0.5.2"
+    micromatch "^2.3.11"
+
+rollup-watch@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/rollup-watch/-/rollup-watch-4.3.1.tgz"
+  integrity sha512-6yjnIwfjpSrqA8IafyIu7fsEyeImNR4aDjA1bQ7KWeVuiA+Clfsx8+PGQkyABWIQzmauQ//tIJ5wAxLXsXs8qQ==
+  dependencies:
+    chokidar "^1.7.0"
+    require-relative "0.8.7"
+    rollup-pluginutils "^2.0.1"
+
+rollup@0.36.3:
+  version "0.36.3"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-0.36.3.tgz"
+  integrity sha1-yJrEeYKJJP+PacHURUHLTqL8Efw=
+  dependencies:
+    source-map-support "^0.4.0"
+
+rollup@0.47.6:
+  version "0.47.6"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-0.47.6.tgz"
+  integrity sha512-bH3eWh7MzbiKTQcHQN7Ievqbs/yY7T+ZcJYboBYkp7BkRlAr2DXHPfiqlvlEH/M95giEBpinHEi/s9CVIgYT6w==
+
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
+  integrity sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=
+  dependencies:
+    once "^1.3.0"
+
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+  integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
+
+rx@2.3.24:
+  version "2.3.24"
+  resolved "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz"
+  integrity sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=
+
+rx@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
+  integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
+
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-json-parse@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz"
+  integrity sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz"
+  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
+  dependencies:
+    ret "~0.1.10"
+
+safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+seek-bzip@^1.0.3, seek-bzip@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
+  integrity sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=
+  dependencies:
+    commander "~2.8.1"
+
+selenium-standalone@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-5.5.0.tgz"
+  integrity sha1-AFhPSQ+TxSK0lzeHXAhPHvA3SFA=
+  dependencies:
+    async "1.2.1"
+    commander "2.6.0"
+    lodash "3.9.3"
+    minimist "1.1.0"
+    mkdirp "0.5.0"
+    progress "1.1.8"
+    request "2.51.0"
+    urijs "1.16.1"
+    which "1.1.1"
+    yauzl "^2.5.0"
+
+semver@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
+  integrity sha1-KBmVuAwUSCCUFd28TPUMJpzvVcU=
+
+semver@^5.3.0:
+  version "5.6.0"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+  integrity sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI=
+
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz"
+  integrity sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=
+  dependencies:
+    to-object-path "^0.3.0"
+
+set-immediate-shim@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz"
+  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz"
+  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
+sha.js@^2.3.6:
+  version "2.4.8"
+  resolved "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+  integrity sha1-NwaMLEdra69ALRSknGf1l5IfY08=
+  dependencies:
+    inherits "^2.0.1"
+
+shelljs@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz"
+  integrity sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=
+
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz"
+  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
+
+sntp@0.2.x:
+  version "0.2.4"
+  resolved "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+  integrity sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=
+  dependencies:
+    hoek "0.9.x"
+
+sntp@1.x.x:
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+  integrity sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=
+  dependencies:
+    hoek "2.x.x"
+
+sort-array@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz"
+  integrity sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=
+  dependencies:
+    array-back "^1.0.4"
+    object-get "^2.1.0"
+    typical "^2.6.0"
+
+sort-keys-length@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz"
+  integrity sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=
+  dependencies:
+    sort-keys "^1.0.0"
+
+sort-keys@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
+  integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
+  dependencies:
+    is-plain-obj "^1.0.0"
+
+source-map-resolve@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz"
+  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
+  dependencies:
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-support@^0.4.0:
+  version "0.4.14"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz"
+  integrity sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=
+  dependencies:
+    source-map "^0.5.6"
+
+source-map-support@^0.4.15:
+  version "0.4.16"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz"
+  integrity sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==
+  dependencies:
+    source-map "^0.5.6"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
+source-map@^0.5.0, source-map@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sparkles@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+  integrity sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=
+
+spawn-command@^0.0.2-1:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz"
+  integrity sha1-lUThpDygRfhTGqwaSMspva5iM44=
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
+  dependencies:
+    extend-shallow "^3.0.0"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sshpk@^1.7.0:
+  version "1.15.2"
+  resolved "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz"
+  integrity sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
+stat-mode@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz"
+  integrity sha1-5sgLYjEj19gM8TLOU480YokHJQI=
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
+  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
+stream-combiner2@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
+  integrity sha1-+02KFCDqNidk4hrUeAOXvry0HL4=
+  dependencies:
+    duplexer2 "~0.1.0"
+    readable-stream "^2.0.2"
+
+stream-connect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz"
+  integrity sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=
+  dependencies:
+    array-back "^1.0.2"
+
+stream-shift@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+  integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+stream-via@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz"
+  integrity sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==
+
+string-range@~1.2, string-range@~1.2.1:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz"
+  integrity sha1-qJPtNH5yKZvIO++78qaSqNI51d0=
+
+string-template@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
+  integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
+
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
+  integrity sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^3.0.0"
+
+string_decoder@0.10, string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+stringstream@~0.0.4:
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz"
+  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
+
+strip-ansi@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
+  integrity sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=
+  dependencies:
+    ansi-regex "^0.2.1"
+
+strip-ansi@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-bom-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz"
+  integrity sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=
+  dependencies:
+    first-chunk-stream "^1.0.0"
+    strip-bom "^2.0.0"
+
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+  integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
+  dependencies:
+    is-utf8 "^0.2.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
+strip-dirs@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
+  integrity sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=
+  dependencies:
+    chalk "^1.0.0"
+    get-stdin "^4.0.1"
+    is-absolute "^0.1.5"
+    is-natural-number "^2.0.0"
+    minimist "^1.1.0"
+    sum-up "^1.0.1"
+
+strip-dirs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.0.0.tgz"
+  integrity sha1-YQzbKSggDaAAT0HcuQ/JXNkZoLY=
+  dependencies:
+    is-natural-number "^4.0.1"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+
+strip-json-comments@~1.0.1:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+  integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strip-outer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz"
+  integrity sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
+sum-up@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
+  integrity sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=
+  dependencies:
+    chalk "^1.0.0"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+  integrity sha1-cqJiiU2dQIuVbKBf83su2KbiotU=
+  dependencies:
+    has-flag "^1.0.0"
+
+supports-color@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+  integrity sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
+  dependencies:
+    has-flag "^1.0.0"
+
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
+table-layout@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/table-layout/-/table-layout-0.4.0.tgz"
+  integrity sha1-xw/wRV2a3WO5H3wVp3kmKVwODn0=
+  dependencies:
+    array-back "^1.0.4"
+    deep-extend "~0.4.1"
+    lodash.padend "^4.6.1"
+    typical "^2.6.0"
+    wordwrapjs "^2.0.0"
+
+table-layout@^0.4.2:
+  version "0.4.5"
+  resolved "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz"
+  integrity sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==
+  dependencies:
+    array-back "^2.0.0"
+    deep-extend "~0.6.0"
+    lodash.padend "^4.6.1"
+    typical "^2.6.1"
+    wordwrapjs "^3.0.0"
+
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.npmjs.org/table/-/table-3.8.3.tgz"
+  integrity sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
+
+taffydb@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz"
+  integrity sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=
+
+tar-stream@^1.1.1:
+  version "1.5.2"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
+  integrity sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=
+  dependencies:
+    bl "^1.0.0"
+    end-of-stream "^1.0.0"
+    readable-stream "^2.0.0"
+    xtend "^4.0.0"
+
+tar-stream@^1.5.2:
+  version "1.5.4"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz"
+  integrity sha1-NlSc8E7RrumyowwBQyUiONr5QBY=
+  dependencies:
+    bl "^1.0.0"
+    end-of-stream "^1.0.0"
+    readable-stream "^2.0.0"
+    xtend "^4.0.0"
+
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz"
+  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
+
+temp-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz"
+  integrity sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=
+
+tempfile@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz"
+  integrity sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=
+  dependencies:
+    os-tmpdir "^1.0.0"
+    uuid "^2.0.1"
+
+tempfile@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz"
+  integrity sha1-awRGhWqbERTRhW/8vlCczLCXcmU=
+  dependencies:
+    temp-dir "^1.0.0"
+    uuid "^3.0.1"
+
+test-value@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz"
+  integrity sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=
+  dependencies:
+    array-back "^1.0.2"
+    typical "^2.4.2"
+
+test-value@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz"
+  integrity sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=
+  dependencies:
+    array-back "^1.0.3"
+    typical "^2.6.0"
+
+test-value@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz"
+  integrity sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==
+  dependencies:
+    array-back "^2.0.0"
+    typical "^2.6.1"
+
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+through2-filter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
+  integrity sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=
+  dependencies:
+    through2 "~2.0.0"
+    xtend "~4.0.0"
+
+through2@^0.6.0, through2@^0.6.1:
+  version "0.6.5"
+  resolved "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+  integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
+
+through2@^2.0.0, through2@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+  integrity sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+time-stamp@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
+  integrity sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=
+
+timed-out@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz"
+  integrity sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=
+
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz"
+  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
+
+tiny-lr@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.0.5.tgz"
+  integrity sha512-YrxUSiMgOVh3PnAqtdAUQuUVEVRnqcRCxJ3BHrl/aaWV2fplKKB60oClM0GH2Gio2hcXvkxMUxsC/vXZrQePlg==
+  dependencies:
+    body "^5.1.0"
+    debug "~2.6.7"
+    faye-websocket "~0.10.0"
+    livereload-js "^2.2.2"
+    object-assign "^4.1.0"
+    qs "^6.4.0"
+
+tmp@0.0.29:
+  version "0.0.29"
+  resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz"
+  integrity sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=
+  dependencies:
+    os-tmpdir "~1.0.1"
+
+to-absolute-glob@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz"
+  integrity sha1-HN+kcqnvUMI57maZm2YsoOs5k38=
+  dependencies:
+    extend-shallow "^2.0.1"
+
+to-fast-properties@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+  integrity sha1-8/XAw7pymafvmUJ+RGMyV63kMyA=
+
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz"
+  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+topo@2.x.x:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
+  integrity sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=
+  dependencies:
+    hoek "4.x.x"
+
+tough-cookie@>=0.12.0:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+  integrity sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=
+  dependencies:
+    punycode "^1.4.1"
+
+tough-cookie@~2.3.0:
+  version "2.3.4"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz"
+  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
+  dependencies:
+    punycode "^1.4.1"
+
+tree-kill@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/tree-kill/-/tree-kill-1.1.0.tgz"
+  integrity sha1-yWPc8DciiS7FnLpWnpQLcZVNFyk=
+
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
+  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+tryit@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+  integrity sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=
+
+tunnel-agent@^0.4.0, tunnel-agent@~0.4.0:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+  integrity sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+  dependencies:
+    prelude-ls "~1.1.2"
+
+typedarray-to-buffer@~1.0.0:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz"
+  integrity sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw=
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typical@^2.4.2, typical@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+  integrity sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=
+
+typical@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz"
+  integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uglify-js@^3.1.4:
+  version "3.17.4"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
+
+unbzip2-stream@^1.0.9:
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz"
+  integrity sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==
+  dependencies:
+    buffer "^3.0.1"
+    through "^2.3.6"
+
+underscore@~1.9.1:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz"
+  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
+union@~0.4.3:
+  version "0.4.6"
+  resolved "https://registry.npmjs.org/union/-/union-0.4.6.tgz"
+  integrity sha1-GY+9rrolTniLDvy2MLwR8kopWeA=
+  dependencies:
+    qs "~2.3.3"
+
+unique-stream@^2.0.2:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+  integrity sha1-WqADz76Uxf+GbE59ZouxxNuts2k=
+  dependencies:
+    json-stable-stringify "^1.0.0"
+    through2-filter "^2.0.0"
+
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
+  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
+unzip-response@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz"
+  integrity sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=
+
+urijs@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz"
+  integrity sha1-hZrTGJD1+VKHJ76J8ZMslPtHMeI=
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz"
+  integrity sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=
+
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
+  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
+  dependencies:
+    prepend-http "^1.0.1"
+
+url-regex@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz"
+  integrity sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=
+  dependencies:
+    ip-regex "^1.0.1"
+
+url-to-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz"
+  integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
+
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/url/-/url-0.10.3.tgz"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/use/-/use-3.1.1.tgz"
+  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+  integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
+  dependencies:
+    os-homedir "^1.0.0"
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz"
+  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
+uuid@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+  integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
+
+uuid@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
+
+uuid@^3.0.0:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+  integrity sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=
+
+vali-date@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz"
+  integrity sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
+vinyl-assign@^1.0.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz"
+  integrity sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=
+  dependencies:
+    object-assign "^4.0.1"
+    readable-stream "^2.0.0"
+
+vinyl-fs@^2.2.0:
+  version "2.4.4"
+  resolved "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz"
+  integrity sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=
+  dependencies:
+    duplexify "^3.2.0"
+    glob-stream "^5.3.2"
+    graceful-fs "^4.0.0"
+    gulp-sourcemaps "1.6.0"
+    is-valid-glob "^0.3.0"
+    lazystream "^1.0.0"
+    lodash.isequal "^4.0.0"
+    merge-stream "^1.0.0"
+    mkdirp "^0.5.0"
+    object-assign "^4.0.0"
+    readable-stream "^2.0.4"
+    strip-bom "^2.0.0"
+    strip-bom-stream "^1.0.0"
+    through2 "^2.0.0"
+    through2-filter "^2.0.0"
+    vali-date "^1.0.0"
+    vinyl "^1.0.0"
+
+vinyl@^0.4.3:
+  version "0.4.6"
+  resolved "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+  integrity sha1-LzVsh6VQolVGHza76ypbqL94SEc=
+  dependencies:
+    clone "^0.2.0"
+    clone-stats "^0.0.1"
+
+vinyl@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+  integrity sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=
+  dependencies:
+    clone "^1.0.0"
+    clone-stats "^0.0.1"
+    replace-ext "0.0.1"
+
+vinyl@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+  integrity sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=
+  dependencies:
+    clone "^1.0.0"
+    clone-stats "^0.0.1"
+    replace-ext "0.0.1"
+
+vlq@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz"
+  integrity sha1-FEOdcRiR5oJTVGf4WHxWMOQiKmw=
+
+wait-on@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/wait-on/-/wait-on-2.0.2.tgz"
+  integrity sha1-CoT9BwJMb8Joyw6r5YW+IXqvK6o=
+  dependencies:
+    core-js "^2.4.1"
+    joi "^9.2.0"
+    minimist "^1.2.0"
+    request "^2.78.0"
+    rx "^4.1.0"
+
+walk-back@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz"
+  integrity sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=
+
+walk-back@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/walk-back/-/walk-back-3.0.1.tgz"
+  integrity sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ==
+
+ware@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz"
+  integrity sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=
+  dependencies:
+    wrap-fn "^0.1.0"
+
+websocket-driver@>=0.5.1:
+  version "0.6.5"
+  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+  integrity sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=
+  dependencies:
+    websocket-extensions ">=0.1.1"
+
+websocket-extensions@>=0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+  integrity sha1-domUmcGEtu91Q3fC27DNbLVdKec=
+
+whatwg-fetch@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+  integrity sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=
+
+which@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/which/-/which-1.1.1.tgz"
+  integrity sha1-nOUSRZlGFm4SwIPwjsBzOA/Iy7s=
+  dependencies:
+    is-absolute "^0.1.7"
+
+which@^1.2.12:
+  version "1.2.14"
+  resolved "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+  integrity sha1-mofEN48D6CfOyvGs31bHNsAcFOU=
+  dependencies:
+    isexe "^2.0.0"
+
+wordwrap@^1.0.0, wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
+
+wordwrapjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz"
+  integrity sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=
+  dependencies:
+    array-back "^1.0.3"
+    feature-detect-es6 "^1.3.1"
+    reduce-flatten "^1.0.1"
+    typical "^2.6.0"
+
+wordwrapjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz"
+  integrity sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==
+  dependencies:
+    reduce-flatten "^1.0.1"
+    typical "^2.6.1"
+
+wrap-fn@^0.1.0:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz"
+  integrity sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=
+  dependencies:
+    co "3.1.0"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+  integrity sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=
+  dependencies:
+    mkdirp "^0.5.1"
+
+xml2js@0.4.17:
+  version "0.4.17"
+  resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz"
+  integrity sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
+xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
+  integrity sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=
+  dependencies:
+    lodash "^4.0.0"
+
+xmlcreate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz"
+  integrity sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==
+
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
+
+xtend@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz"
+  integrity sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=
+
+xtend@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz"
+  integrity sha1-XqZXptukRwacLlnFihE4ywxebO4=
+  dependencies:
+    is-object "~0.1.2"
+    object-keys "~0.2.0"
+
+xtend@~2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+  integrity sha1-bv7MKk2tjmlixJAbM3znuoe10os=
+  dependencies:
+    object-keys "~0.4.0"
+
+xtend@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+  integrity sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
+
+yauzl@^2.2.1, yauzl@^2.5.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.7.0.tgz"
+  integrity sha1-4h2EeGi0lvwp6uwj7of90z6bK84=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.0.1"
+
+yauzl@^2.4.2:
+  version "2.8.0"
+  resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz"
+  integrity sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.0.1"


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1208297564683228/1208335742706984/f

### Summary
Introduced a new `productListing.liveStatus` metafield to allow storefronts to protect unreleased products from going live.

### Performed Testing
1. Create symlink in this package directory.
```
npm link
```
2. Reference the symlink in the `juniper-react` directory.
```
npm link @hellojuniper-com/shopify-buy
```
3. Verify that the metafield is appearing the GQL response on the details page: `http://localhost:3000/p/7521856749759`