### PR TITLE
Add `stockCounterThreshold` and `outOfStockPolicy` metafields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "2.21.11",
+  "version": "2.21.12",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -89,6 +89,8 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "processingTime"},
     {namespace: "productListing", key: "liveStatus"},
     {namespace: "productListing", key: "storeIds"},
+    {namespace: "productListing", key: "stockCounterThreshold"},
+    {namespace: "productListing", key: "outOfStockPolicy"},
   ]) {
     ...MetafieldWithReferenceFragment
   }

--- a/src/graphql/ProductFragmentSimplified.graphql
+++ b/src/graphql/ProductFragmentSimplified.graphql
@@ -51,6 +51,8 @@ fragment ProductFragmentSimplified on Product {
     {namespace: "productListing", key: "fundraisedAmount"},
     {namespace: "productListing", key: "liveStatus"},
     {namespace: "productListing", key: "storeIds"},
+    {namespace: "productListing", key: "stockCounterThreshold"},
+    {namespace: "productListing", key: "outOfStockPolicy"},
   ]) {
     ...MetafieldWithReferenceFragment
   }


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1208652515811162/1208720800415413/f

### Summary
* `stockCounterThreshold` – determines when to show how many units are remaining for a given product or variant (i.e. if the value is set to `100` then we only show how many units are remaining once we reach 99 and below).
* `outOfStockPolicy` – determines whether the product will be transitioned to a pre-order after the inventory is depleted

### Performed Testing
Verified that the metafields are being passed through to the client.
