### PR TITLE
[Store Documents][Part 1 of 4] Add support for querying Shopify `Page` objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -447,6 +447,16 @@ declare namespace ShopifyBuy {
     }
 
     /**
+     * https://shopify.dev/docs/api/storefront/latest/objects/Page
+     */
+    export interface Page {
+        id: string;
+        title: string;
+        handle: string;
+        body: string;
+    }
+
+    /**
      * TODO Validate schema matches js-buy
      * Derived from REST API Docs:
      * https://help.shopify.com/api/custom-storefronts/storefront-api/reference/object/shop#fields
@@ -455,15 +465,26 @@ declare namespace ShopifyBuy {
         description: string;
         moneyFormat: string;
         name: string;
-        /**
-         * TODO Add types for the Shop properties below
-         * PaymentSettings, ShopPolicy etc
-         */
         paymentSettings: any;
         primaryDomain: any;
+
+        // Inherited from https://www.npmjs.com/package/@types/shopify-buy:
+
+        /** @deprecated: Use {@link privacyPolicyPage} instead. */
         privacyPolicy: any;
+        /** @deprecated */
         refundPolicy: any;
+        /** @deprecated: Use {@link termsOfServicePage} instead. */
         termsOfService: any;
+
+        // The new Juniper-specific documents of the shop
+
+        /** The {@link Page} object for Juniper's Privacy Policy document. */
+        privacyPolicyPage: Page;
+        /** The {@link Page} object for Juniper's Terms of Service document. */
+        termsOfServicePage: Page;
+        /** The {@link Page} object for Juniper's FAQ document. */
+        faqPolicy: Page;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "shopify-buy",
-  "version": "3.0.0",
+  "name": "@hellojuniper-com/shopify-buy",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shopify-buy",
-      "version": "3.0.0",
+      "name": "@hellojuniper-com/shopify-buy",
+      "version": "3.0.4",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/shopQuery.graphql
+++ b/src/graphql/shopQuery.graphql
@@ -1,3 +1,10 @@
+fragment DocumentPageFragment on Page {
+  id
+  handle
+  title
+  body
+}
+
 query {
   shop {
     paymentSettings {
@@ -11,5 +18,14 @@ query {
       sslEnabled
       url
     }
+  }
+  privacyPolicyPage: page(id: "gid://shopify/Page/49486823485") {
+    ...DocumentPageFragment
+  }
+  termsOfServicePage: page(id: "gid://shopify/Page/49486757949") {
+    ...DocumentPageFragment
+  }
+  faqPage: page(id: "gid://shopify/Page/49486856253") {
+    ...DocumentPageFragment
   }
 }

--- a/src/graphql/shopQuery.graphql
+++ b/src/graphql/shopQuery.graphql
@@ -22,10 +22,10 @@ query {
   privacyPolicyPage: page(id: "gid://shopify/Page/49486823485") {
     ...DocumentPageFragment
   }
-  termsOfServicePage: page(id: "gid://shopify/Page/49486757949") {
+  termsOfServicePage: page(id: "gid://shopify/Page/49486856253") {
     ...DocumentPageFragment
   }
-  faqPage: page(id: "gid://shopify/Page/49486856253") {
+  faqPage: page(id: "gid://shopify/Page/49486757949") {
     ...DocumentPageFragment
   }
 }

--- a/src/shop-resource.js
+++ b/src/shop-resource.js
@@ -25,7 +25,14 @@ class ShopResource extends Resource {
   fetchInfo() {
     return this.graphQLClient
       .send(shopQuery)
-      .then(defaultResolver('shop'));
+      .then(({model, errors}) => {
+        return {
+          ...defaultResolver('shop')(model, errors),
+          ...defaultResolver('privacyPolicy')(model, errors),
+          ...defaultResolver('termsOfService')(model, errors),
+          ...defaultResolver('faq')(model, errors)
+        };
+      });
   }
 
   /**

--- a/src/shop-resource.js
+++ b/src/shop-resource.js
@@ -25,13 +25,15 @@ class ShopResource extends Resource {
   fetchInfo() {
     return this.graphQLClient
       .send(shopQuery)
-      .then(({model, errors}) => {
-        return {
-          ...defaultResolver('shop')(model, errors),
-          ...defaultResolver('privacyPolicy')(model, errors),
-          ...defaultResolver('termsOfService')(model, errors),
-          ...defaultResolver('faq')(model, errors)
-        };
+      .then(async ({model, errors}) => {
+        const [shop, privacyPolicyPage, termsOfServicePage, faqPage] = await Promise.all([
+          defaultResolver('shop')({model, errors}),
+          defaultResolver('privacyPolicyPage')({model, errors}),
+          defaultResolver('termsOfServicePage')({model, errors}),
+          defaultResolver('faqPage')({model, errors})
+        ]);
+
+        return Object.assign({}, shop, {privacyPolicyPage}, {termsOfServicePage}, {faqPage});
       });
   }
 


### PR DESCRIPTION
### Asana Task
n/a

### Summary
_Part 1 of 4 related PRs (#38, #39, #40, #41)_

Up until now, each theme manifest file included its own copy of the FAQ, Terms of Service, and Privacy Policy, which makes it extremely difficult to manage, as there is no single source of truth. However, we maintain these store documents in rich text format under [Shopify > Online Store > Pages](https://admin.shopify.com/store/junipersales/pages?saved_search_id=2726423724223). The Shopify Buy SDK did not include this query out of the box, so this PR extends the functionality to support querying these specific `Page`s.

### Performed Testing
1. Build the SDK and create a symlink:
```sh
# /path-to-project/shopify-buy
npm run install && npm run build && npm run link
```
2. Reference the symlink and run the React app:
```sh
# /path-to-project/juniper-react
npm link @hellojuniper-com/shopify-buy && THEME_FILE=junipercreates.shop/v11 npm run start
```
3. Observe that the `shop.fetchInfo()` call includes the new fields.