### PR TITLE
[Store Documents][Part 2 of 4] Update `Shop` field `faqPolicyPage` name in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -468,7 +468,7 @@ declare namespace ShopifyBuy {
         paymentSettings: any;
         primaryDomain: any;
 
-        // Inherited from https://www.npmjs.com/package/@types/shopify-buy:
+        // Inherited from https://www.npmjs.com/package/@types/shopify-buy
 
         /** @deprecated: Use {@link privacyPolicyPage} instead. */
         privacyPolicy: any;
@@ -484,7 +484,7 @@ declare namespace ShopifyBuy {
         /** The {@link Page} object for Juniper's Terms of Service document. */
         termsOfServicePage: Page;
         /** The {@link Page} object for Juniper's FAQ document. */
-        faqPolicy: Page;
+        faqPolicyPage: Page;
     }
 
     /**


### PR DESCRIPTION
### Asana Task
n/a

### Summary
_Part 2 of 4 related PRs (#38, #39, #40, #41)_

Up until now, each theme manifest file included its own copy of the FAQ, Terms of Service, and Privacy Policy, which makes it extremely difficult to manage, as there is no single source of truth. However, we maintain these store documents in rich text format under [Shopify > Online Store > Pages](https://admin.shopify.com/store/junipersales/pages?saved_search_id=2726423724223). The Shopify Buy SDK did not include this query out of the box, so this PR extends the functionality to support querying these specific `Page`s.

### Performed Testing
1. Build the SDK and create a symlink:
```sh
# /path-to-project/shopify-buy
npm run install && npm run build && npm run link
```
2. Reference the symlink and run the React app:
```sh
# /path-to-project/juniper-react
npm link @hellojuniper-com/shopify-buy && THEME_FILE=junipercreates.shop/v11 npm run start
```
3. Observe that the `shop.fetchInfo()` call includes the new fields.