### PR TITLE
[Store Documents][Part 3 of 4] Bump package version to 3.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.0.4",
+  "version": "3.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hellojuniper-com/shopify-buy",
-      "version": "3.0.4",
+      "version": "3.0.6",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",


### PR DESCRIPTION
### Asana Task
n/a

### Summary
_Part 3 of 4 related PRs (#38, #39, #40, #41)_

Up until now, each theme manifest file included its own copy of the FAQ, Terms of Service, and Privacy Policy, which makes it extremely difficult to manage, as there is no single source of truth. However, we maintain these store documents in rich text format under [Shopify > Online Store > Pages](https://admin.shopify.com/store/junipersales/pages?saved_search_id=2726423724223). The Shopify Buy SDK did not include this query out of the box, so this PR extends the functionality to support querying these specific `Page`s.

### Performed Testing
1. Build the SDK and create a symlink:
```sh
# /path-to-project/shopify-buy
npm run install && npm run build && npm run link
```
2. Reference the symlink and run the React app:
```sh
# /path-to-project/juniper-react
npm link @hellojuniper-com/shopify-buy && THEME_FILE=junipercreates.shop/v11 npm run start
```
3. Observe that the `shop.fetchInfo()` call includes the new fields.