### PR TITLE
Add bundle exclusive product metafield

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hellojuniper-com/shopify-buy",
-      "version": "3.0.7",
+      "version": "3.0.8",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/CartLineFragment.graphql
+++ b/src/graphql/CartLineFragment.graphql
@@ -15,6 +15,11 @@ fragment CartLineFragment on BaseCartLine {
         id
         handle
         title
+        metafieldsWithReference: metafields(identifiers: [
+          {namespace: "productListing", key: "isBundleExclusive"},
+        ]) {
+          ...MetafieldWithReferenceFragment
+        }
       }
       weight
       available: availableForSale

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -91,6 +91,7 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "storeIds"},
     {namespace: "productListing", key: "stockCounterThreshold"},
     {namespace: "productListing", key: "outOfStockPolicy"},
+    {namespace: "productListing", key: "isBundleExclusive"},
   ]) {
     ...MetafieldWithReferenceFragment
   }


### PR DESCRIPTION
### Asana Task
n/a – [Slack thread](https://junipercreates.slack.com/archives/C04AM1MS9ND/p1752674724411279?thread_ts=1752615272.021629&cid=C04AM1MS9ND)

### Summary
Add `productListing.isbundleExclusive` metafield.

### Performed Testing
* Built the package successfully
* Ran `npm link` from this local package
* Ran `npm link @hellojuniper-com/shopify-buy` from the `juniper-react` package
* Opened the app locally and verified that network calls were including the new metafield
