### PR TITLE
Add support for `maxQtyInCart` product metafield

### DIFF
--- a/fixtures/cart-payload-mapper-fixture.js
+++ b/fixtures/cart-payload-mapper-fixture.js
@@ -391,6 +391,7 @@ export const MOCK_CHECKOUT_LINE_ITEMS = [
       product: {
         id: 'gid://shopify/Product/9899493556246',
         handle: 'alex-kassian-strings-of-eden',
+        title: 'Alex Kassian - Strings Of Eden',
         type: {
           name: 'Product',
           kind: 'OBJECT',
@@ -599,6 +600,7 @@ export const MOCK_CHECKOUT_LINE_ITEMS = [
       product: {
         id: 'gid://shopify/Product/9899493589014',
         handle: 'efterklang-tripper',
+        title: 'Efterklang - Tripper',
         type: {
           name: 'Product',
           kind: 'OBJECT',

--- a/src/graphql/CartLineFragment.graphql
+++ b/src/graphql/CartLineFragment.graphql
@@ -17,6 +17,7 @@ fragment CartLineFragment on BaseCartLine {
         title
         metafieldsWithReference: metafields(identifiers: [
           {namespace: "productListing", key: "isBundleExclusive"},
+          {namespace: "productListing", key: "maxQtyInCart"},
         ]) {
           ...MetafieldWithReferenceFragment
         }

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -92,6 +92,7 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "stockCounterThreshold"},
     {namespace: "productListing", key: "outOfStockPolicy"},
     {namespace: "productListing", key: "isBundleExclusive"},
+    {namespace: "productListing", key: "maxQtyInCart"},
   ]) {
     ...MetafieldWithReferenceFragment
   }

--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -6,7 +6,8 @@ fragment VariantWithProductFragment on ProductVariant {
     title
     metafieldsWithReference: metafields(identifiers: [
       {namespace: "taiga", key: "preOrderStopCondition"},
-      {namespace: "taiga", key: "preOrderDateEstimate"}
+      {namespace: "taiga", key: "preOrderDateEstimate"},
+      {namespace: "productListing", key: "maxQtyInCart"},
     ]) {
       ...MetafieldWithReferenceFragment
     }

--- a/src/graphql/VariantWithProductFragmentSimplified.graphql
+++ b/src/graphql/VariantWithProductFragmentSimplified.graphql
@@ -6,7 +6,8 @@ fragment VariantWithProductFragmentSimplified on ProductVariant {
     title
     metafieldsWithReference: metafields(identifiers: [
       {namespace: "taiga", key: "preOrderStopCondition"},
-      {namespace: "taiga", key: "preOrderDateEstimate"}
+      {namespace: "taiga", key: "preOrderDateEstimate"},
+      {namespace: "productListing", key: "maxQtyInCart"},
     ]) {
       ...MetafieldWithReferenceFragment
     }

--- a/src/utilities/cart-mapping-utils.js
+++ b/src/utilities/cart-mapping-utils.js
@@ -60,22 +60,10 @@ export function mapVariant(merchandise) {
     }
   }
 
-  // The actual Cart merchandise and Checkout variant objects map cleanly to each other,
-  // but the SDK wasn't fetching the title from the product object, so we need to remove it
-  const productWithoutTitle = {};
-
-  if (merchandise.product) {
-    for (const key in merchandise.product) {
-      if (merchandise.product.hasOwnProperty(key) && key !== 'title') {
-        productWithoutTitle[key] = merchandise.product[key];
-      }
-    }
-  }
-
   // Add additional properties
   result.priceV2 = merchandise.price;
   result.compareAtPriceV2 = merchandise.compareAtPrice;
-  result.product = productWithoutTitle;
+  result.product = merchandise.product;
   result.type = getVariantType();
 
   return result;


### PR DESCRIPTION
### Asana Task
n/a – Slack request: https://junipercreates.slack.com/archives/GJJK12BD0/p1759354548161159

### Summary
* Add support for a new product metafield `productListing.maxQtyInCart`
* [Extra] Remove hack that was excluding the `cart.lineItems.variant.product.title` field 

### Performed Testing
1. Create a symlink and run the `juniper-react` app locally
```sh
# shopify-buy/
npm link

# juniper-react/
npm link @hellojuniper-com/shopify-buy && THEME_FILE=gorillatag.junipercreates.com/v22.json npm run start
```
2. Confirm that the [Monke Inflatable Costume](https://admin.shopify.com/store/junipersales/products/8183588749503) cannot be added to cart more than twice.
