### PR TITLE
Add backwards compatibility for legacy TypeScript versions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference path="./dist/types/src/pre-order-timeline.d.ts" />
 
-import type {
+import {
     MediaImage,
     Video,
     MetafieldReferenceGenericFile,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hellojuniper-com/shopify-buy",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",


### PR DESCRIPTION
### Asana Task
n/a

### Summary

[@hellojuniper-com/shopify-buy@3.1.0](https://github.com/hellojuniper-com/shopify-buy-sdk/releases/tag/3.1.0) uses `import type` syntax in its `index.d.ts` file. This syntax was introduced in TypeScript 3.8 (March 2020), but [juniper-react](https://github.com/hellojuniper-com/juniper-react) uses TypeScript 3.3.3333 (early 2019), which doesn't support it. 

This is a simple fix to allow backwards compatibility of this package for legacy TypeScript versions.