### PR TITLE
Fix build artifacts for commonjs library consumers

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,7 +24,8 @@ secrets.ejson
 # Sources
 *.md
 *.txt
-src
+/src
+/typescript
 test
 script
 fixtures

--- a/index.d.ts
+++ b/index.d.ts
@@ -557,6 +557,5 @@ declare namespace ShopifyBuy {
     };
 }
 
-declare module '@hellojuniper-com/shopify-buy' {
-    export = ShopifyBuy;
-}
+export = ShopifyBuy;
+export as namespace ShopifyBuy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hellojuniper-com/shopify-buy",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",


### PR DESCRIPTION
## Fix TypeScript compatibility for library consumers

### Problem
PR #45 introduced breaking changes that prevented `juniper-promo-commons` (and potentially other library packages) from building:

1. **`import type` syntax** - Requires TypeScript 3.8+, breaking consumers on older versions (e.g., `juniper-react` on TS 3.3)
2. **Missing type files** - `.npmignore` excluded `dist/types/src/` directory due to overly broad `src` pattern
3. **Module augmentation error** - Top-level imports converted file to module, making `declare module` wrapper invalid (`TS2666: Exports and export assignments are not permitted in module augmentations`)

React consumers (webpack-based) didn't catch these issues due to lenient bundler validation, but library consumers using `tsc` directly hit all three errors.

### Solution
1. Changed `import type` to `import` for TypeScript 3.3+ compatibility
2. Fixed `.npmignore` to only exclude root-level `/src` and `/typescript` directories
3. Replaced `declare module` wrapper with UMD pattern (`export = ShopifyBuy` + `export as namespace ShopifyBuy`) to support both CommonJS and global namespace usage

### Compatibility
✅ TypeScript 3.3+ (juniper-react)
✅ Strict tsc compilation (juniper-promo-commons)
✅ Webpack/bundler-based consumers
✅ All type files included in published package