### PR TITLE
Fetch pages by handle instead of ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/shopQuery.graphql
+++ b/src/graphql/shopQuery.graphql
@@ -19,13 +19,13 @@ query {
       url
     }
   }
-  privacyPolicyPage: page(id: "gid://shopify/Page/49486823485") {
+  privacyPolicyPage: pageByHandle(handle: "privacy-policy") {
     ...DocumentPageFragment
   }
-  termsOfServicePage: page(id: "gid://shopify/Page/49486856253") {
+  termsOfServicePage: pageByHandle(handle: "terms-of-service") {
     ...DocumentPageFragment
   }
-  faqPage: page(id: "gid://shopify/Page/49486757949") {
+  faqPage: pageByHandle(handle: "faq") {
     ...DocumentPageFragment
   }
 }


### PR DESCRIPTION
### Summary
The SDK is now being consumed by a second Shopify store, so the hard-coded Shopify Page resource IDs used to retrieve the terms of service, privacy policy, and FAQ pages are no longer valid for all package consumers. However, by using page handles, we can allow all consumers to access their own respective pages, so long as this has operationally been set up under _Online Store > Pages_ in the Shopify admin console.

### Performed Testing
Using a symlink for this package, verified that the three document pages are loading for the following stores in [`juniper-react`](https://github.com/hellojuniper-com/juniper-react):
* Adopt Me 
  * Shopify account: `junipercreates.myshopify.com`
  * Theme: `adoptme.junipercreates.com/v2.json`
* NerdForge
  * Shopify account: `junipersales.myshopify.com`
  * Theme: `nerdforge.store/v2.json`