### PR TITLE
Add support for handling open pre-order batches without a cutoff date as in-stock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.2.1",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hellojuniper-com/shopify-buy",
-      "version": "3.2.1",
+      "version": "3.3.1",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/typescript/src/pre-order-timeline.ts
+++ b/typescript/src/pre-order-timeline.ts
@@ -57,36 +57,11 @@ const parseMetaobjectFieldList = (fields: MetaobjectField[]): PreOrderBatch => {
 };
 
 /**
- * Deduplicates open-ended batches (null orderCutoffDate) by keeping only the one with the latest estimatedShippingDate
+ * Sorts batches chronologically by orderCutoffDate and estimatedShippingDate, but with null orderCutoffDates last
  * @param batches - Array of batch objects
- * @returns New array with at most one open-ended batch (the one with latest shipping date)
- * @note If multiple open-ended batches have the same estimatedShippingDate, the first one encountered is kept
+ * @returns New sorted array with closed batches first (oldest to newest) and open-ended batches last
  */
-const deduplicateOpenEndedBatches = (batches: PreOrderBatch[]): PreOrderBatch[] => {
-  const openEndedBatches = batches.filter(batch => batch.orderCutoffDate === null);
-  const closedBatches = batches.filter(batch => batch.orderCutoffDate !== null);
-
-  // If there's 0 or 1 open-ended batch, no deduplication needed
-  if (openEndedBatches.length <= 1) {
-    return [...batches];  // Return new array for immutability
-  }
-
-  // Keep only the open-ended batch with the latest estimatedShippingDate
-  const latestOpenEndedBatch = openEndedBatches.reduce((latest, current) =>
-    current.estimatedShippingDate.getTime() > latest.estimatedShippingDate.getTime()
-      ? current
-      : latest
-  );
-
-  return [...closedBatches, latestOpenEndedBatch];
-};
-
-/**
- * Sorts batches by orderCutoffDate (nulls last), with estimatedShippingDate as tie-breaker
- * @param batches - Array of batch objects
- * @returns New sorted array with closed batches first (oldest to newest), open-ended batches last
- */
-const sortBatchesByOrderCutoffDate = (batches: PreOrderBatch[]): PreOrderBatch[] =>
+const sortBatchesChronologically = (batches: PreOrderBatch[]): PreOrderBatch[] =>
   [...batches].sort((a, b) => {
     // Null cutoff dates should come last (current/final batch)
     if (a.orderCutoffDate === null && b.orderCutoffDate === null) {
@@ -261,10 +236,8 @@ export class PreOrderTimeline {
       return new PreOrderTimeline([], fulfillmentLocation, orderDate);
     }
 
-    // 3. Apply functional pipeline: deduplicate and sort
-    const processedBatches = sortBatchesByOrderCutoffDate(
-      deduplicateOpenEndedBatches(parsedBatches)
-    );
+    // 3. Sort pre-order batches by orderCutoffDate and estimatedShippingDate
+    const processedBatches = sortBatchesChronologically(parsedBatches);
 
     // 4. Return new PreOrderTimeline instance
     return new PreOrderTimeline(processedBatches, fulfillmentLocation, orderDate);
@@ -367,8 +340,7 @@ export class PreOrderTimeline {
 // Export private functions for testing
 export const __testing__ = {
   parseMetaobjectFieldList,
-  deduplicateOpenEndedBatches,
-  sortBatchesByOrderCutoffDate,
+  sortBatchesChronologically,
 };
 
 export default PreOrderTimeline;

--- a/typescript/src/pre-order-timeline.ts
+++ b/typescript/src/pre-order-timeline.ts
@@ -82,19 +82,29 @@ const deduplicateOpenEndedBatches = (batches: PreOrderBatch[]): PreOrderBatch[] 
 };
 
 /**
- * Sorts batches by orderCutoffDate (nulls last)
+ * Sorts batches by orderCutoffDate (nulls last), with estimatedShippingDate as tie-breaker
  * @param batches - Array of batch objects
  * @returns New sorted array with closed batches first (oldest to newest), open-ended batches last
- * @note Uses stable sort - batches with equal cutoff dates maintain their relative order
  */
 const sortBatchesByOrderCutoffDate = (batches: PreOrderBatch[]): PreOrderBatch[] =>
   [...batches].sort((a, b) => {
     // Null cutoff dates should come last (current/final batch)
+    if (a.orderCutoffDate === null && b.orderCutoffDate === null) {
+      // Both null - sort by estimatedShippingDate (earliest first)
+      return a.estimatedShippingDate.getTime() - b.estimatedShippingDate.getTime();
+    }
     if (a.orderCutoffDate === null) return 1;
     if (b.orderCutoffDate === null) return -1;
 
-    // Sort by date (oldest first)
-    return a.orderCutoffDate.getTime() - b.orderCutoffDate.getTime();
+    // Sort by orderCutoffDate (oldest first)
+    const cutoffComparison = a.orderCutoffDate.getTime() - b.orderCutoffDate.getTime();
+
+    // If cutoff dates are equal, sort by estimatedShippingDate (earliest first)
+    if (cutoffComparison === 0) {
+      return a.estimatedShippingDate.getTime() - b.estimatedShippingDate.getTime();
+    }
+
+    return cutoffComparison;
   });
 
 /**

--- a/typescript/src/shipping-info.ts
+++ b/typescript/src/shipping-info.ts
@@ -43,12 +43,12 @@ export class ShippingInfo {
     }
 
     public isInStock(): boolean {
-        return (this.preOrderShipOutDate === null);
+        return (this.preOrderShipOutDate === null) || (this.preOrderShipOutDate <= this.orderDate);
     }
 
     public getShipOutDate(): Date {
         const inStockShipOutDate = addBusinessDays(this.orderDate, this.processingInfo.maxDays);
-        return this.preOrderShipOutDate ? new Date(this.preOrderShipOutDate) : inStockShipOutDate;
+        return this.isInStock() ? inStockShipOutDate : new Date(this.preOrderShipOutDate!);
     }
 
     public getArrivalDate(): Date {

--- a/typescript/test/pre-order-timeline.test.ts
+++ b/typescript/test/pre-order-timeline.test.ts
@@ -3,7 +3,7 @@ import { __testing__, PreOrderBatch, PreOrderTimeline } from '../src/pre-order-t
 import { Metafield, MetafieldReferenceMetaobject, MetaobjectField } from '../shared/types';
 import { validateDate, getFieldValue } from '../src/metafield-utils';
 
-const { parseMetaobjectFieldList, deduplicateOpenEndedBatches, sortBatchesByOrderCutoffDate } = __testing__;
+const { parseMetaobjectFieldList, sortBatchesChronologically } = __testing__;
 
 // Helper function to create a Metafield with metaobject references for testing
 function createMetaobjectList(batches: Array<{ cutoff: string | null, shipping: string }>): Metafield {
@@ -263,145 +263,7 @@ describe('parseMetaobjectFields', () => {
   });
 });
 
-describe('deduplicateOpenEndedBatches', () => {
-  describe('no deduplication needed', () => {
-    it('should return new array when no open-ended batches exist', () => {
-      const batches = [
-        { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') },
-        { orderCutoffDate: new Date('2025-02-15'), estimatedShippingDate: new Date('2025-03-01') }
-      ];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result).toEqual(batches);
-      expect(result).not.toBe(batches); // Should be a new array (immutability)
-      expect(result.length).toBe(2);
-    });
-
-    it('should return new array when exactly one open-ended batch exists', () => {
-      const batches = [
-        { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') },
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') }
-      ];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result).toEqual(batches);
-      expect(result).not.toBe(batches); // Should be a new array (immutability)
-      expect(result.length).toBe(2);
-    });
-
-    it('should return new empty array when input is empty', () => {
-      const batches: PreOrderBatch[] = [];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result).toEqual([]);
-      expect(result).not.toBe(batches); // Should be a new array (immutability)
-    });
-
-    it('should not modify original array', () => {
-      const batches = [
-        { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') }
-      ];
-      const original = [...batches];
-      deduplicateOpenEndedBatches(batches);
-
-      expect(batches).toEqual(original);
-    });
-  });
-
-  describe('deduplication needed', () => {
-    it('should keep only the open-ended batch with latest shipping date', () => {
-      const batches = [
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-01-15') },
-        { orderCutoffDate: new Date('2025-01-01'), estimatedShippingDate: new Date('2025-02-01') },
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') }, // Latest
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-02-15') }
-      ];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result.length).toBe(2); // 1 closed + 1 open-ended
-      expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-01'));
-      expect(result[1].orderCutoffDate).toBeNull();
-      expect(result[1].estimatedShippingDate).toEqual(new Date('2025-03-01'));
-    });
-
-    it('should handle all batches being open-ended', () => {
-      const batches = [
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-01-15') },
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') }, // Latest
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-02-15') }
-      ];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result.length).toBe(1);
-      expect(result[0].orderCutoffDate).toBeNull();
-      expect(result[0].estimatedShippingDate).toEqual(new Date('2025-03-01'));
-    });
-
-    it('should keep first when multiple open-ended batches have same shipping date', () => {
-      const batch1 = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') };
-      const batch2 = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') };
-      const batch3 = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') };
-      const batches = [batch1, batch2, batch3];
-
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result.length).toBe(1);
-      expect(result[0]).toBe(batch1); // Should keep first one (tie-breaking)
-    });
-
-    it('should preserve closed batches when deduplicating', () => {
-      const closed1 = { orderCutoffDate: new Date('2025-01-01'), estimatedShippingDate: new Date('2025-02-01') };
-      const closed2 = { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-03-01') };
-      const openEarly = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-04-01') };
-      const openLate = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-05-01') }; // Latest
-
-      const batches = [closed1, openEarly, closed2, openLate];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result.length).toBe(3);
-      expect(result).toContain(closed1);
-      expect(result).toContain(closed2);
-      expect(result).toContain(openLate);
-      expect(result).not.toContain(openEarly);
-    });
-
-    it('should return new array after deduplication', () => {
-      const batches = [
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-01-15') },
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') }
-      ];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result).not.toBe(batches); // Should be a new array
-    });
-  });
-
-  describe('edge cases', () => {
-    it('should handle two open-ended batches', () => {
-      const batches = [
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-01-15') },
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') } // Latest
-      ];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result.length).toBe(1);
-      expect(result[0].estimatedShippingDate).toEqual(new Date('2025-03-01'));
-    });
-
-    it('should handle single open-ended batch', () => {
-      const batches = [
-        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') }
-      ];
-      const result = deduplicateOpenEndedBatches(batches);
-
-      expect(result.length).toBe(1);
-      expect(result[0]).toEqual(batches[0]);
-      expect(result).not.toBe(batches);
-    });
-  });
-});
-
-describe('sortBatchesByOrderCutoffDate', () => {
+describe('sortBatchesChronologically', () => {
   describe('sorting closed batches', () => {
     it('should sort batches chronologically when all have cutoff dates', () => {
       const batches = [
@@ -409,7 +271,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') },
         { orderCutoffDate: new Date('2025-02-15'), estimatedShippingDate: new Date('2025-03-15') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(3);
       expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15')); // Oldest first
@@ -423,7 +285,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const batch3 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-03-01') };
       const batches = [batch1, batch2, batch3];
 
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(3);
       // Sorted by estimatedShippingDate (earliest first)
@@ -438,7 +300,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-02-15'), estimatedShippingDate: new Date('2025-03-01') },
         { orderCutoffDate: new Date('2025-03-15'), estimatedShippingDate: new Date('2025-04-01') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
       expect(result[1].orderCutoffDate).toEqual(new Date('2025-02-15'));
@@ -453,7 +315,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-03-01') },
         { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-15') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(3);
       expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15')); // Oldest closed
@@ -468,7 +330,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const batch4 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-15') };
       const batches = [batch1, batch2, batch3, batch4];
 
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(4);
       expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
@@ -483,7 +345,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const batch3 = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-06-01') };
       const batches = [batch1, batch2, batch3];
 
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(3);
       // Sorted by estimatedShippingDate (earliest first)
@@ -498,7 +360,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: null, estimatedShippingDate: new Date('2025-01-15') },
         { orderCutoffDate: null, estimatedShippingDate: new Date('2025-02-01') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(3);
       // Sorted by estimatedShippingDate (earliest first)
@@ -513,7 +375,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const batches = [
         { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(1);
       expect(result[0]).toEqual(batches[0]);
@@ -523,7 +385,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const batches = [
         { orderCutoffDate: null, estimatedShippingDate: new Date('2025-02-01') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(1);
       expect(result[0]).toEqual(batches[0]);
@@ -531,7 +393,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
 
     it('should handle empty array', () => {
       const batches: PreOrderBatch[] = [];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result).toEqual([]);
     });
@@ -541,7 +403,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') },
         { orderCutoffDate: new Date('2025-02-15'), estimatedShippingDate: new Date('2025-03-01') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result).not.toBe(batches);
     });
@@ -552,7 +414,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') }
       ];
       const original = [...batches];
-      sortBatchesByOrderCutoffDate(batches);
+      sortBatchesChronologically(batches);
 
       expect(batches).toEqual(original);
     });
@@ -565,7 +427,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-12-15'), estimatedShippingDate: new Date('2026-01-01') },
         { orderCutoffDate: null, estimatedShippingDate: new Date('2026-03-01') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result[0].orderCutoffDate).toEqual(new Date('2025-12-15')); // Oldest
       expect(result[1].orderCutoffDate).toEqual(new Date('2026-01-15'));
@@ -578,7 +440,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-02-15'), estimatedShippingDate: new Date('2025-03-15') }, // Batch 2
         { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-15') }  // Batch 1
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(3);
       expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
@@ -593,7 +455,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-03-01') },
         { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-15') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(4);
       // First by cutoff date (Jan 15), then by estimated shipping date
@@ -615,7 +477,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
         { orderCutoffDate: null, estimatedShippingDate: new Date('2025-06-01') },
         { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-03-01') }
       ];
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(4);
       // Closed batches first, sorted by cutoff date then estimated shipping date
@@ -635,7 +497,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const batch2 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') };
       const batches = [batch1, batch2];
 
-      const result = sortBatchesByOrderCutoffDate(batches);
+      const result = sortBatchesChronologically(batches);
 
       expect(result.length).toBe(2);
       // Both have same dates, order is stable (comparison returns 0)
@@ -759,20 +621,22 @@ describe('PreOrderTimeline.fromMetaobjectList', () => {
       expect(batches[2].orderCutoffDate).toBeNull();
     });
 
-    it('should deduplicate multiple open-ended batches', () => {
+    it('should preserve multiple open-ended batches', () => {
       const metaobjectList = createMetaobjectList([
         { cutoff: null, shipping: '2025-03-01' },
         { cutoff: '2025-01-15', shipping: '2025-02-15' },
-        { cutoff: null, shipping: '2025-05-01' } // Latest open-ended
+        { cutoff: null, shipping: '2025-05-01' }
       ]);
 
       const timeline = PreOrderTimeline.fromMetaobjectList(metaobjectList);
       const batches = timeline.getBatches();
 
-      expect(batches.length).toBe(2); // Should have deduplicated to 1 closed + 1 open-ended
-      expect(batches[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
-      expect(batches[1].orderCutoffDate).toBeNull();
-      expect(batches[1].estimatedShippingDate).toEqual(new Date('2025-05-01')); // Latest kept
+      expect(batches.length).toBe(3); // All batches preserved
+      expect(batches[0].orderCutoffDate).toEqual(new Date('2025-01-15')); // Closed first
+      expect(batches[1].orderCutoffDate).toBeNull(); // Open-ended sorted by shipping date
+      expect(batches[1].estimatedShippingDate).toEqual(new Date('2025-03-01'));
+      expect(batches[2].orderCutoffDate).toBeNull();
+      expect(batches[2].estimatedShippingDate).toEqual(new Date('2025-05-01'));
     });
 
     it('should preserve custom orderDate for multiple batches', () => {
@@ -788,9 +652,104 @@ describe('PreOrderTimeline.fromMetaobjectList', () => {
     });
   });
 
+  describe('multiple open-ended batches', () => {
+    it('should sort multiple open-ended batches by estimatedShippingDate', () => {
+      const metaobjectList = createMetaobjectList([
+        { cutoff: null, shipping: '2025-06-01' },
+        { cutoff: null, shipping: '2025-03-01' },
+        { cutoff: null, shipping: '2025-09-01' }
+      ]);
+
+      const timeline = PreOrderTimeline.fromMetaobjectList(metaobjectList);
+      const batches = timeline.getBatches();
+
+      expect(batches.length).toBe(3);
+      // All open-ended batches sorted by estimatedShippingDate (earliest first)
+      expect(batches[0].estimatedShippingDate).toEqual(new Date('2025-03-01'));
+      expect(batches[1].estimatedShippingDate).toEqual(new Date('2025-06-01'));
+      expect(batches[2].estimatedShippingDate).toEqual(new Date('2025-09-01'));
+    });
+
+    it('should place all open-ended batches after closed batches', () => {
+      const metaobjectList = createMetaobjectList([
+        { cutoff: null, shipping: '2025-04-01' },
+        { cutoff: '2025-02-01', shipping: '2025-03-01' },
+        { cutoff: null, shipping: '2025-06-01' },
+        { cutoff: '2025-01-15', shipping: '2025-02-15' },
+        { cutoff: null, shipping: '2025-05-01' }
+      ]);
+
+      const timeline = PreOrderTimeline.fromMetaobjectList(metaobjectList);
+      const batches = timeline.getBatches();
+
+      expect(batches.length).toBe(5);
+      // Closed batches first, sorted by orderCutoffDate
+      expect(batches[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
+      expect(batches[1].orderCutoffDate).toEqual(new Date('2025-02-01'));
+      // Open-ended batches last, sorted by estimatedShippingDate
+      expect(batches[2].orderCutoffDate).toBeNull();
+      expect(batches[2].estimatedShippingDate).toEqual(new Date('2025-04-01'));
+      expect(batches[3].orderCutoffDate).toBeNull();
+      expect(batches[3].estimatedShippingDate).toEqual(new Date('2025-05-01'));
+      expect(batches[4].orderCutoffDate).toBeNull();
+      expect(batches[4].estimatedShippingDate).toEqual(new Date('2025-06-01'));
+    });
+
+    it('should return first open-ended batch for getBatchForOrderDate when past all cutoff dates', () => {
+      const metaobjectList = createMetaobjectList([
+        { cutoff: '2025-01-15', shipping: '2025-02-15' },
+        { cutoff: null, shipping: '2025-06-01' },
+        { cutoff: null, shipping: '2025-04-01' }
+      ]);
+
+      // Order date is after all cutoff dates
+      const orderDate = new Date('2025-02-01');
+      const timeline = PreOrderTimeline.fromMetaobjectList(metaobjectList, 'CN', orderDate);
+      const batch = timeline.getBatchForOrderDate();
+
+      // Should return the first open-ended batch (earliest shipping date)
+      expect(batch).not.toBeNull();
+      expect(batch!.orderCutoffDate).toBeNull();
+      expect(batch!.estimatedShippingDate).toEqual(new Date('2025-04-01'));
+    });
+
+    it('should return correct estimated shipping date with multiple open-ended batches', () => {
+      const metaobjectList = createMetaobjectList([
+        { cutoff: '2025-01-15', shipping: '2025-02-15' },
+        { cutoff: null, shipping: '2025-06-01' },
+        { cutoff: null, shipping: '2025-04-01' }
+      ]);
+
+      // Order date is after all cutoff dates
+      const orderDate = new Date('2025-02-01');
+      const timeline = PreOrderTimeline.fromMetaobjectList(metaobjectList, 'CN', orderDate);
+
+      // Should return the shipping date of the first open-ended batch (earliest)
+      expect(timeline.getEstimatedShippingDate()).toEqual(new Date('2025-04-01'));
+    });
+
+    it('should handle open-ended batches with identical shipping dates', () => {
+      const metaobjectList = createMetaobjectList([
+        { cutoff: null, shipping: '2025-04-01' },
+        { cutoff: null, shipping: '2025-04-01' },
+        { cutoff: null, shipping: '2025-04-01' }
+      ]);
+
+      const timeline = PreOrderTimeline.fromMetaobjectList(metaobjectList);
+      const batches = timeline.getBatches();
+
+      expect(batches.length).toBe(3);
+      // All have the same dates, all preserved
+      batches.forEach(batch => {
+        expect(batch.orderCutoffDate).toBeNull();
+        expect(batch.estimatedShippingDate).toEqual(new Date('2025-04-01'));
+      });
+    });
+  });
+
   describe('error handling - resilient filtering', () => {
     it('should filter out batch missing estimatedShippingDate', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       const metaobjectList: Metafield = {
         id: 'gid://shopify/Metafield/123',
@@ -822,7 +781,7 @@ describe('PreOrderTimeline.fromMetaobjectList', () => {
     });
 
     it('should filter out batch with invalid date format', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       const metaobjectList: Metafield = {
         id: 'gid://shopify/Metafield/123',
@@ -850,7 +809,7 @@ describe('PreOrderTimeline.fromMetaobjectList', () => {
     });
 
     it('should keep valid batches and filter out invalid ones', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       const metaobjectList: Metafield = {
         id: 'gid://shopify/Metafield/123',
@@ -900,7 +859,7 @@ describe('PreOrderTimeline.fromMetaobjectList', () => {
     });
 
     it('should filter out batch when fields is not an array', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       const metaobjectList: Metafield = {
         id: 'gid://shopify/Metafield/123',
@@ -926,7 +885,7 @@ describe('PreOrderTimeline.fromMetaobjectList', () => {
     });
 
     it('should include batch index in error message', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       const metaobjectList: Metafield = {
         id: 'gid://shopify/Metafield/123',
@@ -969,7 +928,7 @@ describe('PreOrderTimeline.fromMetaobjectList', () => {
     });
 
     it('should handle all invalid batches gracefully', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       const metaobjectList: Metafield = {
         id: 'gid://shopify/Metafield/123',
@@ -1602,7 +1561,7 @@ describe('PreOrderTimeline.getByDateAndLocation', () => {
 
   describe('error handling', () => {
     it('should return empty timeline on parsing error', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       const invalidTimeline: Metafield = {
         id: 'gid://shopify/Metafield/123',
@@ -1641,7 +1600,7 @@ describe('PreOrderTimeline.getByDateAndLocation', () => {
     });
 
     it('should log error and return empty timeline on exception in try-catch', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
       // This will cause an error when accessing .value on undefined
       const timeline = PreOrderTimeline.getByDateAndLocation(
@@ -1693,11 +1652,11 @@ describe('PreOrderTimeline.getByDateAndLocation', () => {
       expect(batches[2].orderCutoffDate).toBeNull();
     });
 
-    it('should handle international customer with deduplication', () => {
+    it('should handle international customer with multiple open-ended batches', () => {
       const wwTimeline = createMetaobjectList([
         { cutoff: '2025-01-15', shipping: '2025-02-01' },
         { cutoff: null, shipping: '2025-03-01' },
-        { cutoff: null, shipping: '2025-04-01' } // Should be deduplicated to latest
+        { cutoff: null, shipping: '2025-04-01' }
       ]);
 
       const timeline = PreOrderTimeline.getByDateAndLocation(
@@ -1714,10 +1673,12 @@ describe('PreOrderTimeline.getByDateAndLocation', () => {
       );
 
       const batches = timeline.getBatches();
-      expect(batches.length).toBe(2); // 1 closed + 1 deduplicated open-ended
+      expect(batches.length).toBe(3); // 1 closed + 2 open-ended (all preserved)
       expect(batches[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
       expect(batches[1].orderCutoffDate).toBeNull();
-      expect(batches[1].estimatedShippingDate).toEqual(new Date('2025-04-01')); // Latest kept
+      expect(batches[1].estimatedShippingDate).toEqual(new Date('2025-03-01'));
+      expect(batches[2].orderCutoffDate).toBeNull();
+      expect(batches[2].estimatedShippingDate).toEqual(new Date('2025-04-01'));
     });
   });
 });

--- a/typescript/test/pre-order-timeline.test.ts
+++ b/typescript/test/pre-order-timeline.test.ts
@@ -417,18 +417,19 @@ describe('sortBatchesByOrderCutoffDate', () => {
       expect(result[2].orderCutoffDate).toEqual(new Date('2025-03-01')); // Newest last
     });
 
-    it('should maintain stable sort for batches with same cutoff date', () => {
-      const batch1 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') };
-      const batch2 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-03-01') };
-      const batch3 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-04-01') };
+    it('should sort by estimatedShippingDate when cutoff dates are equal', () => {
+      const batch1 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-04-01') };
+      const batch2 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') };
+      const batch3 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-03-01') };
       const batches = [batch1, batch2, batch3];
 
       const result = sortBatchesByOrderCutoffDate(batches);
 
       expect(result.length).toBe(3);
-      expect(result[0]).toBe(batch1); // Same order preserved
-      expect(result[1]).toBe(batch2);
-      expect(result[2]).toBe(batch3);
+      // Sorted by estimatedShippingDate (earliest first)
+      expect(result[0]).toBe(batch2); // Feb 1
+      expect(result[1]).toBe(batch3); // Mar 1
+      expect(result[2]).toBe(batch1); // Apr 1
     });
 
     it('should sort already sorted array correctly', () => {
@@ -476,7 +477,7 @@ describe('sortBatchesByOrderCutoffDate', () => {
       expect(result[3].orderCutoffDate).toBeNull();
     });
 
-    it('should preserve order of null batches (stable sort)', () => {
+    it('should sort null batches by estimatedShippingDate', () => {
       const batch1 = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-05-01') };
       const batch2 = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') };
       const batch3 = { orderCutoffDate: null, estimatedShippingDate: new Date('2025-06-01') };
@@ -485,12 +486,13 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const result = sortBatchesByOrderCutoffDate(batches);
 
       expect(result.length).toBe(3);
-      expect(result[0]).toBe(batch1); // Order preserved
-      expect(result[1]).toBe(batch2);
-      expect(result[2]).toBe(batch3);
+      // Sorted by estimatedShippingDate (earliest first)
+      expect(result[0]).toBe(batch2); // Mar 1
+      expect(result[1]).toBe(batch1); // May 1
+      expect(result[2]).toBe(batch3); // Jun 1
     });
 
-    it('should handle all null cutoff dates', () => {
+    it('should handle all null cutoff dates by sorting by estimatedShippingDate', () => {
       const batches = [
         { orderCutoffDate: null, estimatedShippingDate: new Date('2025-03-01') },
         { orderCutoffDate: null, estimatedShippingDate: new Date('2025-01-15') },
@@ -499,10 +501,10 @@ describe('sortBatchesByOrderCutoffDate', () => {
       const result = sortBatchesByOrderCutoffDate(batches);
 
       expect(result.length).toBe(3);
-      // All null, so order should be preserved (stable sort)
-      expect(result[0].estimatedShippingDate).toEqual(new Date('2025-03-01'));
-      expect(result[1].estimatedShippingDate).toEqual(new Date('2025-01-15'));
-      expect(result[2].estimatedShippingDate).toEqual(new Date('2025-02-01'));
+      // Sorted by estimatedShippingDate (earliest first)
+      expect(result[0].estimatedShippingDate).toEqual(new Date('2025-01-15'));
+      expect(result[1].estimatedShippingDate).toEqual(new Date('2025-02-01'));
+      expect(result[2].estimatedShippingDate).toEqual(new Date('2025-03-01'));
     });
   });
 
@@ -582,6 +584,63 @@ describe('sortBatchesByOrderCutoffDate', () => {
       expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
       expect(result[1].orderCutoffDate).toEqual(new Date('2025-02-15'));
       expect(result[2].orderCutoffDate).toBeNull();
+    });
+
+    it('should sort by cutoff date first, then by estimated shipping date as tie-breaker', () => {
+      const batches = [
+        { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-04-01') },
+        { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-03-15') },
+        { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-03-01') },
+        { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-15') }
+      ];
+      const result = sortBatchesByOrderCutoffDate(batches);
+
+      expect(result.length).toBe(4);
+      // First by cutoff date (Jan 15), then by estimated shipping date
+      expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
+      expect(result[0].estimatedShippingDate).toEqual(new Date('2025-02-15'));
+      expect(result[1].orderCutoffDate).toEqual(new Date('2025-01-15'));
+      expect(result[1].estimatedShippingDate).toEqual(new Date('2025-03-15'));
+      // Then cutoff date (Feb 1), then by estimated shipping date
+      expect(result[2].orderCutoffDate).toEqual(new Date('2025-02-01'));
+      expect(result[2].estimatedShippingDate).toEqual(new Date('2025-03-01'));
+      expect(result[3].orderCutoffDate).toEqual(new Date('2025-02-01'));
+      expect(result[3].estimatedShippingDate).toEqual(new Date('2025-04-01'));
+    });
+
+    it('should handle mixed closed and null batches with tie-breakers', () => {
+      const batches = [
+        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-07-01') },
+        { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-04-01') },
+        { orderCutoffDate: null, estimatedShippingDate: new Date('2025-06-01') },
+        { orderCutoffDate: new Date('2025-02-01'), estimatedShippingDate: new Date('2025-03-01') }
+      ];
+      const result = sortBatchesByOrderCutoffDate(batches);
+
+      expect(result.length).toBe(4);
+      // Closed batches first, sorted by cutoff date then estimated shipping date
+      expect(result[0].orderCutoffDate).toEqual(new Date('2025-02-01'));
+      expect(result[0].estimatedShippingDate).toEqual(new Date('2025-03-01'));
+      expect(result[1].orderCutoffDate).toEqual(new Date('2025-02-01'));
+      expect(result[1].estimatedShippingDate).toEqual(new Date('2025-04-01'));
+      // Null batches last, sorted by estimated shipping date
+      expect(result[2].orderCutoffDate).toBeNull();
+      expect(result[2].estimatedShippingDate).toEqual(new Date('2025-06-01'));
+      expect(result[3].orderCutoffDate).toBeNull();
+      expect(result[3].estimatedShippingDate).toEqual(new Date('2025-07-01'));
+    });
+
+    it('should handle batches with identical cutoff and estimated shipping dates', () => {
+      const batch1 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') };
+      const batch2 = { orderCutoffDate: new Date('2025-01-15'), estimatedShippingDate: new Date('2025-02-01') };
+      const batches = [batch1, batch2];
+
+      const result = sortBatchesByOrderCutoffDate(batches);
+
+      expect(result.length).toBe(2);
+      // Both have same dates, order is stable (comparison returns 0)
+      expect(result[0].orderCutoffDate).toEqual(new Date('2025-01-15'));
+      expect(result[1].orderCutoffDate).toEqual(new Date('2025-01-15'));
     });
   });
 });

--- a/typescript/test/shipping-info.test.ts
+++ b/typescript/test/shipping-info.test.ts
@@ -90,6 +90,20 @@ describe('ShippingInfo', () => {
 
       expect(shippingInfo.isInStock()).toBe(false);
     });
+
+    it('should return true when preOrderShipOutDate is before orderDate', () => {
+      const shippingInfo = new ShippingInfo(
+        new Date('2025-02-01'),  // orderDate
+        new Date('2025-01-15'),  // preOrderShipOutDate (before orderDate)
+        { minDays: 1, maxDays: 3 },
+        { minDays: 7, maxDays: 16 },
+        'CN',
+        'US',
+        new Date('2025-12-12')
+      );
+
+      expect(shippingInfo.isInStock()).toBe(true);
+    });
   });
 
   describe('getShipOutDate', () => {
@@ -146,6 +160,27 @@ describe('ShippingInfo', () => {
 
       // Original should not be modified
       expect(shippingInfo.getShipOutDate().toISOString()).toBe('2025-02-01T00:00:00.000Z');
+    });
+
+    it('should return orderDate + maxProcessingDays when preOrderShipOutDate is before orderDate', () => {
+      // Monday, February 3, 2025 at noon
+      const orderDate = new Date(2025, 1, 3, 12, 0, 0);
+      const preOrderShipOutDate = new Date(2025, 0, 15, 12, 0, 0); // Jan 15 - before order date
+      const shippingInfo = new ShippingInfo(
+        orderDate,
+        preOrderShipOutDate,
+        { minDays: 1, maxDays: 3 },
+        { minDays: 7, maxDays: 16 },
+        'CN',
+        'US',
+        new Date('2025-12-12')
+      );
+
+      const shipOutDate = shippingInfo.getShipOutDate();
+      // Should use in-stock logic: 3 business days from Mon Feb 3 = Thu Feb 6
+      expect(shipOutDate.getFullYear()).toBe(2025);
+      expect(shipOutDate.getMonth()).toBe(1); // February
+      expect(shipOutDate.getDate()).toBe(6);
     });
   });
 
@@ -271,6 +306,34 @@ describe('ShippingInfo', () => {
       expect(dateRange.latest.getFullYear()).toBe(2025);
       expect(dateRange.latest.getMonth()).toBe(0); // January
       expect(dateRange.latest.getDate()).toBe(16);
+    });
+
+    it('should use in-stock calculation when preOrderShipOutDate is before orderDate', () => {
+      // Monday, February 3, 2025 at noon
+      const orderDate = new Date(2025, 1, 3, 12, 0, 0);
+      const preOrderShipOutDate = new Date(2025, 0, 15, 12, 0, 0); // Jan 15 - before order date
+      const shippingInfo = new ShippingInfo(
+        orderDate,
+        preOrderShipOutDate,
+        { minDays: 1, maxDays: 3 },
+        { minDays: 5, maxDays: 10 },
+        'CN',
+        'US',
+        new Date('2025-12-12')
+      );
+
+      const dateRange = shippingInfo.getArrivalDateRange();
+
+      // Should use in-stock logic: processing + delivery from order date
+      // Earliest: 1 + 5 = 6 business days from Mon Feb 3 = Tue Feb 11
+      expect(dateRange.earliest.getFullYear()).toBe(2025);
+      expect(dateRange.earliest.getMonth()).toBe(1); // February
+      expect(dateRange.earliest.getDate()).toBe(11);
+
+      // Latest: 3 + 10 = 13 business days from Mon Feb 3 = Thu Feb 20
+      expect(dateRange.latest.getFullYear()).toBe(2025);
+      expect(dateRange.latest.getMonth()).toBe(1); // February
+      expect(dateRange.latest.getDate()).toBe(20);
     });
   });
 
@@ -560,6 +623,25 @@ describe('ShippingInfo', () => {
       const result = shippingInfo.getShipsOutAndArrivesDisplayValues();
       expect(result.shipsOut).toBeInstanceOf(Date);
       expect((result.shipsOut as Date).toISOString()).toBe('2025-02-01T00:00:00.000Z');
+      expect(result.arrives).toEqual(deliveryInfo);
+    });
+
+    it('should return processing info as shipsOut when preOrderShipOutDate is before orderDate', () => {
+      const processingInfo = { minDays: 1, maxDays: 3 };
+      const deliveryInfo = { minDays: 7, maxDays: 16 };
+      const shippingInfo = new ShippingInfo(
+        new Date('2025-02-01'),  // orderDate
+        new Date('2025-01-15'),  // preOrderShipOutDate (before orderDate)
+        processingInfo,
+        deliveryInfo,
+        'CN',
+        'US',
+        new Date('2025-12-12')
+      );
+
+      const result = shippingInfo.getShipsOutAndArrivesDisplayValues();
+      // Should use in-stock logic: return processing info, not ship out date
+      expect(result.shipsOut).toEqual(processingInfo);
       expect(result.arrives).toEqual(deliveryInfo);
     });
   });

--- a/typescript/test/shipping-info.test.ts
+++ b/typescript/test/shipping-info.test.ts
@@ -104,6 +104,21 @@ describe('ShippingInfo', () => {
 
       expect(shippingInfo.isInStock()).toBe(true);
     });
+
+    it('should return true when preOrderShipOutDate equals orderDate', () => {
+      const sameDate = new Date('2025-02-01');
+      const shippingInfo = new ShippingInfo(
+        sameDate,  // orderDate
+        sameDate,  // preOrderShipOutDate (same as orderDate)
+        { minDays: 1, maxDays: 3 },
+        { minDays: 7, maxDays: 16 },
+        'CN',
+        'US',
+        new Date('2025-12-12')
+      );
+
+      expect(shippingInfo.isInStock()).toBe(true);
+    });
   });
 
   describe('getShipOutDate', () => {


### PR DESCRIPTION
### Summary
An edge case was flagged [on Slack](https://junipercreates.slack.com/archives/C05FA40TQ21/p1764353572510109) where a product that initially launched on pre-order eventually went in-stock after the inventory from the initial pre-order batch was fulfilled. This led to a scenario that we did not account for in the timeline, where a product could transition from pre-order to in-stock.

To address this, we now consider an open-ended pre-order batch (i.e. a `PreOrderBatch` with `orderCutoffDate === null`) to be treated as in-stock if the order date is after the batch's estimated shipping date.

### Real Scenario
In the Denji Plush example from the Slack conversation, the product was on pre-order in Sep 2025 with an estimated shipping date of Nov 20. However, orders between Nov 20 and Nov 29 were placed while the product was in-stock before eventually going back on pre-order on Nov 30. 

At the time the first PO was fulfilled on Nov 20, the pre-order timeline looked like this:

```json
[{
  "orderCutoffDate": null,
  "estimatedShippingDate": "2025-11-20T00:00:00Z"
}, {
  "orderCutoffDate": null,
  "estimatedShippingDate": "2026-04-30T00:00:00Z"
}]
```

As of Nov 21, the first pre-order batch in the timeline implied that the product was in-stock.

However, once the remaining inventory in the first PO finished selling through on Nov 30, the pre-order timeline was updated to this:

```json
[{
  "orderCutoffDate": "2025-11-30T00:00:00Z",
  "estimatedShippingDate": "2025-11-20T00:00:00Z"
}, {
  "orderCutoffDate": null,
  "estimatedShippingDate": "2026-04-30T00:00:00Z"
}]
```

As of Nov 30, the second pre-order batch in the timeline implied that the product was no longer in-stock.

### Changes
- Updated the pre-order batch sorting logic to be chronologically by order cutoff date and estimated shipping date, where `null` order cutoff dates are placed last.
- Updated the pre-order batch logic to support multiple open-ended pre-order batches.
- Updated the shipping info to display in-stock processing times if the estimated pre-order shipping date is before the order date.

### Performed Testing
Updated unit tests.