### PR TITLE
Request the productListing.audioCardDescription product metafield

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hellojuniper-com/shopify-buy",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellojuniper-com/shopify-buy",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Juniper's forked version of the shopify-buy Javascript SDK.",
   "main": "index.js",
   "jsnext:main": "index.es.js",

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -93,6 +93,7 @@ fragment ProductFragment on Product {
     {namespace: "productListing", key: "outOfStockPolicy"},
     {namespace: "productListing", key: "isBundleExclusive"},
     {namespace: "productListing", key: "maxQtyInCart"},
+    {namespace: "productListing", key: "audioCardDescription"},
   ]) {
     ...MetafieldWithReferenceFragment
   }


### PR DESCRIPTION
## Summary
- Adds `{namespace: "productListing", key: "audioCardDescription"}` to `ProductFragment`'s `metafieldsWithReference` list so the Storefront API returns it on every product fetch.
- Backs a new per-product audio ("voice box") card description in juniper-react, replacing copy that was previously hard-coded for a single product (Jeffy Piano).
- Patch version bump `3.3.1` → `3.3.2` (purely additive, backward-compatible).

## Prerequisites
- The metafield definition `productListing.audioCardDescription` (single-line text) already exists in the `junipersales` Shopify store.
- The consumer change lives in juniper-react (separate PR) and depends on this package being published as `3.3.2`.

## Test plan
- [x] `npm run build` succeeds; the new identifier is present in the compiled bundle.
- [x] Storefront API accepts the identifier and returns the field (`null` when unset, not an error) — verified against products `8388261019839` and `7817729573055`.
- [x] Publish `3.3.2` to GitHub Packages so juniper-react can consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJvUsLPP8RZj8UqSLNhBoL